### PR TITLE
Add host.name tag based on os.Hostname

### DIFF
--- a/launcher/config.go
+++ b/launcher/config.go
@@ -294,7 +294,7 @@ func newResource(c *Config) *resource.Resource {
 
 	hostnameSet := false
 	for iter := r.Iter(); iter.Next(); {
-		if iter.Attribute().Key == conventions.AttributeHostName {
+		if iter.Attribute().Key == conventions.AttributeHostName && len(iter.Attribute().Value.Emit()) > 0 {
 			hostnameSet = true
 		}
 	}
@@ -329,7 +329,7 @@ func newResource(c *Config) *resource.Resource {
 	if !hostnameSet {
 		hostname, err := os.Hostname()
 		if err != nil {
-			c.logger.Debugf("host.name not set: %v", err)
+			c.logger.Debugf("unable to set host.name. Set OTEL_RESOURCE_ATTRIBUTES=\"host.name=<your_host_name>\" env var or configure WithResourceAttributes in code: %v", err)
 		} else {
 			attributes = append(attributes, label.String(conventions.AttributeHostName, hostname))
 		}

--- a/launcher/config.go
+++ b/launcher/config.go
@@ -294,6 +294,7 @@ func newResource(c *Config) *resource.Resource {
 	if reset {
 		os.Unsetenv("OTEL_RESOURCE_LABELS")
 	}
+
 	attributes := []label.KeyValue{
 		label.String(conventions.AttributeTelemetrySDKName, "launcher"),
 		label.String(conventions.AttributeTelemetrySDKLanguage, "go"),
@@ -306,6 +307,10 @@ func newResource(c *Config) *resource.Resource {
 
 	if len(c.ServiceVersion) > 0 {
 		attributes = append(attributes, label.String(conventions.AttributeServiceVersion, c.ServiceVersion))
+	}
+
+	if hostname, err := os.Hostname(); err == nil {
+		attributes = append(attributes, label.String(conventions.AttributeHostName, hostname))
 	}
 
 	for key, value := range c.resourceAttributes {

--- a/launcher/config_test.go
+++ b/launcher/config_test.go
@@ -272,7 +272,8 @@ func TestDebugEnabled(t *testing.T) {
 		WithSpanExporterEndpoint("localhost:443"),
 		WithLogLevel("debug"),
 		WithResourceAttributes(map[string]string{
-			"attr1": "val1",
+			"attr1":     "val1",
+			"host.name": "host456",
 		}),
 	)
 	defer lsOtel.Shutdown()
@@ -280,9 +281,11 @@ func TestDebugEnabled(t *testing.T) {
 	assert.Contains(t, output, "debug logging enabled")
 	assert.Contains(t, output, "test-service")
 	assert.Contains(t, output, "access-token-123")
-	assert.Contains(t, output, "ocalhost:443")
+	assert.Contains(t, output, "localhost:443")
 	assert.Contains(t, output, "attr1")
 	assert.Contains(t, output, "val1")
+	assert.Contains(t, output, "host.name")
+	assert.Contains(t, output, "host456")
 }
 
 func TestDefaultConfig(t *testing.T) {
@@ -489,14 +492,14 @@ func TestConfigureResourcesAttributes(t *testing.T) {
 	}
 	assert.Equal(t, expected, resource.Attributes())
 
-	os.Setenv("OTEL_RESOURCE_ATTRIBUTES", "service.name=test-service-b")
+	os.Setenv("OTEL_RESOURCE_ATTRIBUTES", "service.name=test-service-b,host.name=host123")
 	config = Config{
 		ServiceName:    "test-service-b",
 		ServiceVersion: "test-version",
 	}
 	resource = newResource(&config)
 	expected = []label.KeyValue{
-		label.String("host.name", host()),
+		label.String("host.name", "host123"),
 		label.String("service.name", "test-service-b"),
 		label.String("service.version", "test-version"),
 		label.String("telemetry.sdk.language", "go"),

--- a/launcher/config_test.go
+++ b/launcher/config_test.go
@@ -521,6 +521,25 @@ func TestServiceNameViaResourceAttributes(t *testing.T) {
 	}
 }
 
+func TestEmptyHostnameDefaultsToOsHostname(t *testing.T) {
+	os.Setenv("OTEL_RESOURCE_ATTRIBUTES", "host.name=")
+	logger := &testLogger{}
+	lsOtel := ConfigureOpentelemetry(
+		WithLogger(logger),
+		WithServiceName("test-service"),
+		WithSpanExporterEndpoint("localhost:443"),
+		WithLogLevel("debug"),
+		WithResourceAttributes(map[string]string{
+			"attr1":     "val1",
+			"host.name": "",
+		}),
+	)
+	defer lsOtel.Shutdown()
+	output := strings.Join(logger.output[:], ",")
+	assert.Contains(t, output, "host.name")
+	assert.Contains(t, output, host())
+}
+
 func setEnvironment() {
 	os.Setenv("LS_SERVICE_NAME", "test-service-name")
 	os.Setenv("LS_SERVICE_VERSION", "test-service-version")

--- a/launcher/config_test.go
+++ b/launcher/config_test.go
@@ -294,6 +294,7 @@ func TestDefaultConfig(t *testing.T) {
 	)
 
 	attributes := []label.KeyValue{
+		label.String("host.name", host()),
 		label.String("service.version", "unknown"),
 		label.String("telemetry.sdk.name", "launcher"),
 		label.String("telemetry.sdk.language", "go"),
@@ -328,6 +329,7 @@ func TestEnvironmentVariables(t *testing.T) {
 	)
 
 	attributes := []label.KeyValue{
+		label.String("host.name", host()),
 		label.String("service.name", "test-service-name"),
 		label.String("service.version", "test-service-version"),
 		label.String("telemetry.sdk.name", "launcher"),
@@ -374,6 +376,7 @@ func TestConfigurationOverrides(t *testing.T) {
 	)
 
 	attributes := []label.KeyValue{
+		label.String("host.name", host()),
 		label.String("service.name", "override-service-name"),
 		label.String("service.version", "override-service-version"),
 		label.String("telemetry.sdk.name", "launcher"),
@@ -446,6 +449,11 @@ func TestConfigurePropagators(t *testing.T) {
 	}
 }
 
+func host() string {
+	host, _ := os.Hostname()
+	return host
+}
+
 func TestConfigureResourcesAttributes(t *testing.T) {
 	os.Setenv("OTEL_RESOURCE_ATTRIBUTES", "label1=value1,label2=value2")
 	config := Config{
@@ -454,6 +462,7 @@ func TestConfigureResourcesAttributes(t *testing.T) {
 	}
 	resource := newResource(&config)
 	expected := []label.KeyValue{
+		label.String("host.name", host()),
 		label.String("label1", "value1"),
 		label.String("label2", "value2"),
 		label.String("service.name", "test-service"),
@@ -471,6 +480,7 @@ func TestConfigureResourcesAttributes(t *testing.T) {
 	}
 	resource = newResource(&config)
 	expected = []label.KeyValue{
+		label.String("host.name", host()),
 		label.String("service.name", "test-service"),
 		label.String("service.version", "test-version"),
 		label.String("telemetry.sdk.language", "go"),
@@ -486,6 +496,7 @@ func TestConfigureResourcesAttributes(t *testing.T) {
 	}
 	resource = newResource(&config)
 	expected = []label.KeyValue{
+		label.String("host.name", host()),
 		label.String("service.name", "test-service-b"),
 		label.String("service.version", "test-version"),
 		label.String("telemetry.sdk.language", "go"),


### PR DESCRIPTION
The current implementation takes the `os.Hostname` value and sets is for the `host.name` attribute.

Fixes #18 