### PR TITLE
Add 6 example OTel-Go Metric instruments 

### DIFF
--- a/examples/metrics/metrics.go
+++ b/examples/metrics/metrics.go
@@ -45,6 +45,13 @@ func main() {
 	ctx := context.Background()
 	meter := metric.Must(otel.Meter("testing"))
 
+	// This example shows 1 instrument each for (UpDown)?(SumObserver|Counter)
+	// The two monotonic instruments of these have a fixed rate of +1.
+	// The two non-monotonic instruments of these have a fixed rate of -1.
+	// There are 2 example ValueObserver instruments (one a Gaussian, one a Sine wave).
+	//
+	// TODO: ValueRecorder examples.
+
 	c1 := meter.NewInt64Counter(prefix + "counter")
 	c2 := meter.NewInt64UpDownCounter(prefix + "updowncounter")
 	go func() {

--- a/examples/metrics/metrics.go
+++ b/examples/metrics/metrics.go
@@ -23,12 +23,71 @@
 package main
 
 import (
+	"context"
+	"fmt"
+	"math"
+	"math/rand"
+	"os"
 	"time"
 
 	"github.com/lightstep/otel-launcher-go/launcher"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/label"
+	"go.opentelemetry.io/otel/metric"
 )
 
 func main() {
 	defer launcher.ConfigureOpentelemetry().Shutdown()
-	time.Sleep(time.Second)
+
+	name := os.Getenv("LS_SERVICE_NAME")
+	prefix := fmt.Sprint("otel.", name, ".")
+
+	ctx := context.Background()
+	meter := metric.Must(otel.Meter("testing"))
+
+	c1 := meter.NewInt64Counter(prefix + "counter")
+	c2 := meter.NewInt64UpDownCounter(prefix + "updowncounter")
+	go func() {
+		for {
+			c1.Add(ctx, 1)
+			c2.Add(ctx, -1)
+			time.Sleep(time.Second)
+		}
+	}()
+
+	startTime := time.Now()
+
+	meter.NewInt64SumObserver(
+		prefix+"sumobserver",
+		func(_ context.Context, result metric.Int64ObserverResult) {
+			result.Observe(int64(time.Since(startTime).Seconds()))
+		},
+	)
+
+	meter.NewInt64UpDownSumObserver(
+		prefix+"updownsumobserver",
+		func(_ context.Context, result metric.Int64ObserverResult) {
+			result.Observe(-int64(time.Since(startTime).Seconds()))
+		},
+	)
+
+	meter.NewInt64ValueObserver(
+		prefix+"valueobserver",
+		func(_ context.Context, result metric.Int64ObserverResult) {
+			result.Observe(int64(50 + rand.NormFloat64()*50))
+		},
+	)
+
+	meter.NewFloat64ValueObserver(
+		prefix+"sine_wave",
+		func(_ context.Context, result metric.Float64ObserverResult) {
+			secs := float64(time.Now().UnixNano()) / float64(time.Second)
+
+			result.Observe(math.Sin(secs/(200*math.Pi)), label.String("period", "fast"))
+			result.Observe(math.Sin(secs/(1000*math.Pi)), label.String("period", "regular"))
+			result.Observe(math.Sin(secs/(5000*math.Pi)), label.String("period", "slow"))
+		},
+	)
+
+	select {}
 }

--- a/examples/metrics/metrics.go
+++ b/examples/metrics/metrics.go
@@ -96,5 +96,7 @@ func main() {
 		},
 	)
 
-	select {}
+	if os.Getenv("NOHANG") == "" {
+		select {}
+	}
 }

--- a/examples/metrics/metrics_test.go
+++ b/examples/metrics/metrics_test.go
@@ -25,5 +25,6 @@ func TestMinimumConfiguration(t *testing.T) {
 	os.Setenv("LS_SERVICE_NAME", "test-service-name")
 	os.Setenv("OTEL_EXPORTER_OTLP_SPAN_ENDPOINT", "invalid-endpoint")
 	os.Setenv("OTEL_EXPORTER_OTLP_METRIC_ENDPOINT", "invalid-endpoint")
+	os.Setenv("NOHANG", "true")
 	assert.NotPanics(t, main)
 }


### PR DESCRIPTION
**Description:** Adds more examples of OTel metrics instruments in use. Self-documenting.