### PR TITLE
use OTEL_SERVICE_NAME instead of LS_SERVICE_NAME

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,11 +10,18 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [1.0.0](https://github.com/lightstep/otel-launcher-go/releases/tag/v1.0.0) - 2021-09-22
 
+### Breaking change
+
+- Removed support for `LS_SERVICE_NAME` in favour of OpenTelemetry standard `OTEL_SERVICE_NAME`
+
 ### Changed
+
 - Update OpenTelemetry tracing dependencies to 1.0.0
+
 ## [1.0.0-RC3](https://github.com/lightstep/otel-launcher-go/releases/tag/v1.0.0-RC3) - 2021-09-15
 
 ### Changed
+
 - Update OpenTelemetry tracing dependencies to 1.0.0-RC3
 - Update OpenTelemetry metrics dependencies to 0.23.0
 - Remove support for deprecated `OTEL_RESOURCE_LABELS` environment variable, as
@@ -23,25 +30,30 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ## [0.20.0](https://github.com/lightstep/otel-launcher-go/releases/tag/v0.20.0) - 2021-05-10
 
 ### Changed
+
 - Update OpenTelemetry dependencies to 0.20.0
 
 ## [0.18.0](https://github.com/lightstep/otel-launcher-go/releases/tag/v0.18.0) - 2021-03-16
 
 ### Changed
+
 - Update OpenTelemetry dependencies to 0.18.0
 
 ### Added
+
 - Add support for `ottrace` propagator
 
 ## [0.16.1](https://github.com/lightstep/otel-launcher-go/releases/tag/v0.16.1) - 2021-02-01
 
 ### Changed
+
 - Enable gzip compression by default
 - Update OpenTelemetry dependencies to 0.16.0
 
 ## [0.15.0](https://github.com/lightstep/otel-launcher-go/releases/tag/v0.15.0) - 2020-12-15
 
 ### Changed
+
 - Update OpenTelemetry dependencies to 0.15.0
 - Added context param for NewExporter as required by OpenTelemetry 0.15.0
 
@@ -54,9 +66,11 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ## [0.14.0](https://github.com/lightstep/otel-launcher-go/releases/tag/v0.14.0) - 2020-11-23
 
 ### Changed
+
 - Update configuration for baggage propagator from `"cc"` to `"baggage"` (#30)
 
 ### Added
+
 - Add support for `tracecontext` propagator (#32)
 - Adding LS_METRICS_ENABLED env variable to control host/runtime metrics (#34)
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Additional options
 
 |Config Option     |Env Variable      |Required|Default|
 |------------------|------------------|--------|-------|
-|WithServiceName            |LS_SERVICE_NAME                    |y       |-                               |
+|WithServiceName            |OTEL_SERVICE_NAME                  |y       |-                               |
 |WithServiceVersion         |LS_SERVICE_VERSION                 |n       |unknown                         |
 |WithSpanExporterEndpoint   |OTEL_EXPORTER_OTLP_SPAN_ENDPOINT   |n       |ingest.lightstep.com:443        |
 |WithSpanExporterInsecure   |OTEL_EXPORTER_OTLP_SPAN_INSECURE   |n       |false                           |

--- a/examples/metrics/metrics.go
+++ b/examples/metrics/metrics.go
@@ -15,7 +15,7 @@
 // Package main configures OpenTelemetry metrics and starts reporting
 // runtime and host metrics.  For example:
 //
-//   LS_SERVICE_NAME=foo \
+//   OTEL_SERVICE_NAME=foo \
 //   OTEL_EXPORTER_OTLP_SPAN_ENDPOINT=localhost:9999 \
 //   OTEL_EXPORTER_OTLP_METRIC_ENDPOINT=localhost:9999 \
 //   go run ./metrics.go
@@ -39,7 +39,7 @@ import (
 func main() {
 	defer launcher.ConfigureOpentelemetry().Shutdown()
 
-	name := os.Getenv("LS_SERVICE_NAME")
+	name := os.Getenv("OTEL_SERVICE_NAME")
 	prefix := fmt.Sprint("otel.", name, ".")
 
 	ctx := context.Background()

--- a/examples/metrics/metrics_test.go
+++ b/examples/metrics/metrics_test.go
@@ -22,7 +22,7 @@ import (
 )
 
 func TestMinimumConfiguration(t *testing.T) {
-	os.Setenv("LS_SERVICE_NAME", "test-service-name")
+	os.Setenv("OTEL_SERVICE_NAME", "test-service-name")
 	os.Setenv("OTEL_EXPORTER_OTLP_SPAN_ENDPOINT", "invalid-endpoint")
 	os.Setenv("OTEL_EXPORTER_OTLP_METRIC_ENDPOINT", "invalid-endpoint")
 	os.Setenv("NOHANG", "true")

--- a/examples/tracing/trace_test.go
+++ b/examples/tracing/trace_test.go
@@ -22,7 +22,7 @@ import (
 )
 
 func TestMinimumConfiguration(t *testing.T) {
-	os.Setenv("LS_SERVICE_NAME", "test-service-name")
+	os.Setenv("OTEL_SERVICE_NAME", "test-service-name")
 	os.Setenv("OTEL_EXPORTER_OTLP_SPAN_ENDPOINT", "invalid-endpoint")
 	os.Setenv("OTEL_EXPORTER_OTLP_METRIC_ENDPOINT", "invalid-endpoint")
 	assert.NotPanics(t, main)

--- a/launcher/config.go
+++ b/launcher/config.go
@@ -186,7 +186,7 @@ const (
 type Config struct {
 	SpanExporterEndpoint           string   `env:"OTEL_EXPORTER_OTLP_SPAN_ENDPOINT,default=ingest.lightstep.com:443"`
 	SpanExporterEndpointInsecure   bool     `env:"OTEL_EXPORTER_OTLP_SPAN_INSECURE,default=false"`
-	ServiceName                    string   `env:"LS_SERVICE_NAME"`
+	ServiceName                    string   `env:"OTEL_SERVICE_NAME"`
 	ServiceVersion                 string   `env:"LS_SERVICE_VERSION,default=unknown"`
 	MetricExporterEndpoint         string   `env:"OTEL_EXPORTER_OTLP_METRIC_ENDPOINT,default=ingest.lightstep.com:443"`
 	MetricExporterEndpointInsecure bool     `env:"OTEL_EXPORTER_OTLP_METRIC_INSECURE,default=false"`
@@ -224,7 +224,7 @@ func validateConfiguration(c Config) error {
 			}
 		}
 		if !serviceNameSet {
-			return errors.New("invalid configuration: service name missing. Set LS_SERVICE_NAME env var or configure WithServiceName in code")
+			return errors.New("invalid configuration: service name missing. Set OTEL_SERVICE_NAME env var or configure WithServiceName in code")
 		}
 	}
 

--- a/launcher/config_test.go
+++ b/launcher/config_test.go
@@ -571,7 +571,7 @@ func TestEmptyHostnameDefaultsToOsHostname(t *testing.T) {
 }
 
 func setEnvironment() {
-	os.Setenv("LS_SERVICE_NAME", "test-service-name")
+	os.Setenv("OTEL_SERVICE_NAME", "test-service-name")
 	os.Setenv("LS_SERVICE_VERSION", "test-service-version")
 	os.Setenv("LS_ACCESS_TOKEN", "token")
 	os.Setenv("OTEL_EXPORTER_OTLP_SPAN_ENDPOINT", "satellite-url")
@@ -586,7 +586,7 @@ func setEnvironment() {
 
 func unsetEnvironment() {
 	vars := []string{
-		"LS_SERVICE_NAME",
+		"OTEL_SERVICE_NAME",
 		"LS_SERVICE_VERSION",
 		"LS_ACCESS_TOKEN",
 		"OTEL_EXPORTER_OTLP_SPAN_ENDPOINT",


### PR DESCRIPTION
**Description:** 
Before releasing 1.0.0, removing the custom LS_SERVICE_NAME variable, in favour of supporting the standard OTEL_SERVICE_NAME

