### PR TITLE
Start dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+- package-ecosystem: gomod
+  directory: /
+  labels:
+  - dependencies
+  schedule:
+    interval: daily

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,3 +12,9 @@ updates:
   - dependencies
   schedule:
     interval: daily
+- package-ecosystem: gomod
+  directory: /tools
+  labels:
+  - dependencies
+  schedule:
+    interval: daily

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,3 +6,9 @@ updates:
   - dependencies
   schedule:
     interval: daily
+- package-ecosystem: gomod
+  directory: /pipelines
+  labels:
+  - dependencies
+  schedule:
+    interval: daily


### PR DESCRIPTION
**Description:** 

Adds dependabot to track out of date versions

**Documentation:**

In prep for starting a release schedule, this is introducing the tools needed to track if we are out of date with our dependencies. 