### PR TITLE
fix/typo: add the missing "," in the example

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ func main() {
         launcher.WithHeaders(map[string]string{
             "service-auth-key": "value",
             "service-useful-field": "testing",
-        })
+        }),
     )
     defer otel.Shutdown()
 }


### PR DESCRIPTION
The example code in README.md misses a character "," after the function parameter.
Add this "," to make it more convienient for users.
