### PR TITLE
Use the (correct) provided resource attributes

### DIFF
--- a/launcher/config.go
+++ b/launcher/config.go
@@ -311,7 +311,7 @@ func newResource(c *Config) *resource.Resource {
 			if key == string(semconv.HostNameKey) {
 				hostnameSet = true
 			}
-			attributes = append(attributes, semconv.HostNameKey.String(value))
+			attributes = append(attributes, attribute.String(key, value))
 		}
 	}
 

--- a/launcher/config_test.go
+++ b/launcher/config_test.go
@@ -551,21 +551,21 @@ func TestServiceNameViaResourceAttributes(t *testing.T) {
 
 func TestEmptyHostnameDefaultsToOsHostname(t *testing.T) {
 	os.Setenv("OTEL_RESOURCE_ATTRIBUTES", "host.name=")
-	logger := &testLogger{}
 	lsOtel := ConfigureOpentelemetry(
-		WithLogger(logger),
 		WithServiceName("test-service"),
 		WithSpanExporterEndpoint("localhost:443"),
-		WithLogLevel("debug"),
+		WithAccessToken(fakeAccessToken()),
 		WithResourceAttributes(map[string]string{
 			"attr1":     "val1",
 			"host.name": "",
 		}),
 	)
 	defer lsOtel.Shutdown()
-	output := strings.Join(logger.output[:], ",")
-	assert.Contains(t, output, "host.name")
-	assert.Contains(t, output, host())
+
+	attrs := attribute.NewSet(lsOtel.config.Resource.Attributes()...)
+	v, ok := attrs.Value("host.name")
+	assert.Equal(t, host(), v.AsString())
+	assert.True(t, ok)
 }
 
 func TestConfigWithResourceAttributes(t *testing.T) {

--- a/launcher/config_test.go
+++ b/launcher/config_test.go
@@ -568,6 +568,27 @@ func TestEmptyHostnameDefaultsToOsHostname(t *testing.T) {
 	assert.Contains(t, output, host())
 }
 
+func TestConfigWithResourceAttributes(t *testing.T) {
+	lsOtel := ConfigureOpentelemetry(
+		WithServiceName("test-service"),
+		WithSpanExporterEndpoint("localhost:443"),
+		WithAccessToken(fakeAccessToken()),
+		WithResourceAttributes(map[string]string{
+			"attr1": "val1",
+			"attr2": "val2",
+		}),
+	)
+	defer lsOtel.Shutdown()
+	attrs := attribute.NewSet(lsOtel.config.Resource.Attributes()...)
+	v, ok := attrs.Value("attr1")
+	assert.Equal(t, "val1", v.AsString())
+	assert.True(t, ok)
+
+	v, ok = attrs.Value("attr2")
+	assert.Equal(t, "val2", v.AsString())
+	assert.True(t, ok)
+}
+
 func setEnvironment() {
 	os.Setenv("LS_SERVICE_NAME", "test-service-name")
 	os.Setenv("LS_SERVICE_VERSION", "test-service-version")


### PR DESCRIPTION
**Description:**  
Fixes #163 

**Testing:** 
Embarrassingly, there was one existing test that mentioned `WithResourceAttributes()`, and it does verify something, but it uses the logger output for verification and because the logger logs the configuration, the thing being tested for appears despite the bug.

A new test verifies the correct behavior.
