### PR TITLE
Add the Asynchronous and Synchronous state packages for review LS-29754

### DIFF
--- a/lightstep/sdk/metric/internal/asyncstate/async.go
+++ b/lightstep/sdk/metric/internal/asyncstate/async.go
@@ -1,0 +1,142 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package asyncstate // import "github.com/lightstep/otel-launcher-go/lightstep/sdk/metric/internal/asyncstate"
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"github.com/lightstep/otel-launcher-go/lightstep/sdk/metric/internal/pipeline"
+	"github.com/lightstep/otel-launcher-go/lightstep/sdk/metric/internal/viewstate"
+	"github.com/lightstep/otel-launcher-go/lightstep/sdk/metric/number"
+	"github.com/lightstep/otel-launcher-go/lightstep/sdk/metric/sdkinstrument"
+)
+
+type (
+	// State is the object used to maintain independent collection
+	// state for each asynchronous meter.
+	State struct {
+		// pipe is the pipeline.Register number of this state.
+		pipe int
+
+		// lock protects against errant use of the instrument
+		// w/ copied context after the callback returns.
+		lock sync.Mutex
+
+		// store is a map from instrument to set of values
+		// observed during one collection.
+		store map[*Instrument]map[attribute.Set]viewstate.Accumulator
+	}
+
+	// Instrument is the implementation object associated with one
+	// asynchronous instrument.
+	Instrument struct {
+		// opaque is used to ensure that callbacks are
+		// registered with instruments from the same provider.
+		opaque interface{}
+
+		// compiled is the per-pipeline compiled instrument.
+		compiled pipeline.Register[viewstate.Instrument]
+
+		// descriptor describes the API-level instrument.
+		//
+		// Note: Not clear why we need this. It's used for a
+		// range test, but shouldn't the range test be
+		// performed by the aggregator?  If a View is allowed
+		// to reconfigure the aggregation in ways that change
+		// semantics, should the range test be based on the
+		// aggregation, not the original instrument?
+		descriptor sdkinstrument.Descriptor
+	}
+
+	// contextKey is used with context.WithValue() to lookup
+	// per-reader state from within an executing callback
+	// function.
+	contextKey struct{}
+)
+
+func NewState(pipe int) *State {
+	return &State{
+		pipe:  pipe,
+		store: map[*Instrument]map[attribute.Set]viewstate.Accumulator{},
+	}
+}
+
+// NewInstrument returns a new Instrument; this compiles individual
+// instruments for each reader.
+func NewInstrument(desc sdkinstrument.Descriptor, opaque interface{}, compiled pipeline.Register[viewstate.Instrument]) *Instrument {
+	return &Instrument{
+		opaque:     opaque,
+		descriptor: desc,
+		compiled:   compiled,
+	}
+}
+
+// SnapshotAndProcess calls SnapshotAndProcess() on each of the pending
+// aggregations for a given reader.
+func (inst *Instrument) SnapshotAndProcess(state *State) {
+	state.lock.Lock()
+	defer state.lock.Unlock()
+
+	for _, acc := range state.store[inst] {
+		acc.SnapshotAndProcess()
+	}
+}
+
+func (inst *Instrument) get(cs *callbackState, attrs []attribute.KeyValue) viewstate.Accumulator {
+	comp := inst.compiled[cs.state.pipe]
+
+	cs.state.lock.Lock()
+	defer cs.state.lock.Unlock()
+
+	aset := attribute.NewSet(attrs...)
+	imap, has := cs.state.store[inst]
+
+	if !has {
+		imap = map[attribute.Set]viewstate.Accumulator{}
+		cs.state.store[inst] = imap
+	}
+
+	se, has := imap[aset]
+	if !has {
+		se = comp.NewAccumulator(aset)
+		imap[aset] = se
+	}
+	return se
+}
+
+func capture[N number.Any, Traits number.Traits[N]](ctx context.Context, inst *Instrument, value N, attrs []attribute.KeyValue) {
+	lookup := ctx.Value(contextKey{})
+	if lookup == nil {
+		otel.Handle(fmt.Errorf("async instrument used outside of callback"))
+		return
+	}
+
+	cs := lookup.(*callbackState)
+	cb := cs.getCallback()
+	if cb == nil {
+		otel.Handle(fmt.Errorf("async instrument used after callback return"))
+		return
+	}
+	if _, ok := cb.instruments[inst]; !ok {
+		otel.Handle(fmt.Errorf("async instrument not declared for use in callback"))
+		return
+	}
+
+	inst.get(cs, attrs).(viewstate.Updater[N]).Update(value)
+}

--- a/lightstep/sdk/metric/internal/asyncstate/async_test.go
+++ b/lightstep/sdk/metric/internal/asyncstate/async_test.go
@@ -1,0 +1,298 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package asyncstate // import "github.com/lightstep/otel-launcher-go/lightstep/sdk/metric/internal/asyncstate"
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/lightstep/otel-launcher-go/lightstep/sdk/metric/aggregator/aggregation"
+	"github.com/lightstep/otel-launcher-go/lightstep/sdk/metric/aggregator/sum"
+	"github.com/lightstep/otel-launcher-go/lightstep/sdk/metric/data"
+	"github.com/lightstep/otel-launcher-go/lightstep/sdk/metric/internal/pipeline"
+	"github.com/lightstep/otel-launcher-go/lightstep/sdk/metric/internal/test"
+	"github.com/lightstep/otel-launcher-go/lightstep/sdk/metric/internal/viewstate"
+	"github.com/lightstep/otel-launcher-go/lightstep/sdk/metric/number"
+	"github.com/lightstep/otel-launcher-go/lightstep/sdk/metric/sdkinstrument"
+	"github.com/lightstep/otel-launcher-go/lightstep/sdk/metric/view"
+	"go.opentelemetry.io/otel/metric/instrument"
+	"go.opentelemetry.io/otel/sdk/instrumentation"
+)
+
+var (
+	testLibrary = instrumentation.Library{
+		Name: "test",
+	}
+
+	endTime    = time.Unix(100, 0)
+	middleTime = endTime.Add(-time.Millisecond)
+	startTime  = endTime.Add(-2 * time.Millisecond)
+
+	testSequence = data.Sequence{
+		Start: startTime,
+		Last:  middleTime,
+		Now:   endTime,
+	}
+)
+
+type testSDK struct {
+	compiler *viewstate.Compiler
+}
+
+func (tsdk *testSDK) compile(desc sdkinstrument.Descriptor) pipeline.Register[viewstate.Instrument] {
+	comp, err := tsdk.compiler.Compile(desc)
+	if err != nil {
+		panic(err)
+	}
+	reg := pipeline.NewRegister[viewstate.Instrument](1)
+	reg[0] = comp
+	return reg
+}
+
+func testAsync(name string, opts ...view.Option) *testSDK {
+	return &testSDK{
+		compiler: viewstate.New(testLibrary, view.New(name, opts...)),
+	}
+}
+
+func testState() *State {
+	return NewState(0)
+}
+
+func testObserver[N number.Any, Traits number.Traits[N]](tsdk *testSDK, name string, ik sdkinstrument.Kind, opts ...instrument.Option) Observer[N, Traits] {
+	var t Traits
+	desc := test.Descriptor(name, ik, t.Kind(), opts...)
+	impl := NewInstrument(desc, tsdk, tsdk.compile(desc))
+	return NewObserver[N, Traits](impl)
+}
+
+func TestNewCallbackError(t *testing.T) {
+	tsdk := testAsync("test")
+
+	// no instruments error
+	cb, err := NewCallback(nil, tsdk, nil)
+	require.Error(t, err)
+	require.Nil(t, cb)
+
+	// nil callback error
+	cntr := testObserver[int64, number.Int64Traits](tsdk, "counter", sdkinstrument.CounterObserverKind)
+	cb, err = NewCallback([]instrument.Asynchronous{cntr}, tsdk, nil)
+	require.Error(t, err)
+	require.Nil(t, cb)
+}
+
+func TestNewCallbackProviderMismatch(t *testing.T) {
+	test0 := testAsync("test0")
+	test1 := testAsync("test1")
+
+	instA0 := testObserver[int64, number.Int64Traits](test0, "A", sdkinstrument.CounterObserverKind)
+	instB1 := testObserver[float64, number.Float64Traits](test1, "A", sdkinstrument.CounterObserverKind)
+
+	cb, err := NewCallback([]instrument.Asynchronous{instA0, instB1}, test0, func(context.Context) {})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "asynchronous instrument belongs to a different meter")
+	require.Nil(t, cb)
+
+	cb, err = NewCallback([]instrument.Asynchronous{instA0, instB1}, test1, func(context.Context) {})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "asynchronous instrument belongs to a different meter")
+	require.Nil(t, cb)
+
+	cb, err = NewCallback([]instrument.Asynchronous{instA0}, test0, func(context.Context) {})
+	require.NoError(t, err)
+	require.NotNil(t, cb)
+
+	cb, err = NewCallback([]instrument.Asynchronous{instB1}, test1, func(context.Context) {})
+	require.NoError(t, err)
+	require.NotNil(t, cb)
+
+	// nil value not of this SDK
+	var fake0 instrument.Asynchronous
+	cb, err = NewCallback([]instrument.Asynchronous{fake0}, test0, func(context.Context) {})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "asynchronous instrument does not belong to this SDK")
+	require.Nil(t, cb)
+
+	// non-nil value not of this SDK
+	var fake1 struct {
+		instrument.Asynchronous
+	}
+	cb, err = NewCallback([]instrument.Asynchronous{fake1}, test0, func(context.Context) {})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "asynchronous instrument does not belong to this SDK")
+	require.Nil(t, cb)
+}
+
+func TestCallbackInvalidation(t *testing.T) {
+	errors := test.OTelErrors()
+
+	tsdk := testAsync("test")
+
+	var called int64
+	var saveCtx context.Context
+
+	cntr := testObserver[int64, number.Int64Traits](tsdk, "counter", sdkinstrument.CounterObserverKind)
+	cb, err := NewCallback([]instrument.Asynchronous{cntr}, tsdk, func(ctx context.Context) {
+		cntr.Observe(ctx, called)
+		saveCtx = ctx
+		called++
+	})
+	require.NoError(t, err)
+
+	state := testState()
+
+	// run the callback once legitimately
+	cb.Run(context.Background(), state)
+
+	// simulate use after callback return
+	cntr.Observe(saveCtx, 10000000)
+
+	cntr.inst.SnapshotAndProcess(state)
+
+	require.Equal(t, int64(1), called)
+	require.Equal(t, 1, len(*errors))
+	require.Contains(t, (*errors)[0].Error(), "used after callback return")
+
+	test.RequireEqualMetrics(
+		t,
+		test.CollectScope(
+			t,
+			tsdk.compiler.Collectors(),
+			testSequence,
+		),
+		test.Instrument(
+			cntr.inst.descriptor,
+			test.Point(startTime, endTime, sum.NewMonotonicInt64(0), aggregation.CumulativeTemporality),
+		),
+	)
+}
+
+func TestCallbackUndeclaredInstrument(t *testing.T) {
+	errors := test.OTelErrors()
+
+	tt := testAsync("test")
+
+	var called int64
+
+	cntr1 := testObserver[int64, number.Int64Traits](tt, "counter1", sdkinstrument.CounterObserverKind)
+	cntr2 := testObserver[int64, number.Int64Traits](tt, "counter2", sdkinstrument.CounterObserverKind)
+
+	cb, err := NewCallback([]instrument.Asynchronous{cntr1}, tt, func(ctx context.Context) {
+		cntr2.Observe(ctx, called)
+		called++
+	})
+	require.NoError(t, err)
+
+	state := testState()
+
+	// run the callback once legitimately
+	cb.Run(context.Background(), state)
+
+	cntr1.inst.SnapshotAndProcess(state)
+	cntr2.inst.SnapshotAndProcess(state)
+
+	require.Equal(t, int64(1), called)
+	require.Equal(t, 1, len(*errors))
+	require.Contains(t, (*errors)[0].Error(), "instrument not declared for use in callback")
+
+	test.RequireEqualMetrics(
+		t,
+		test.CollectScope(
+			t,
+			tt.compiler.Collectors(),
+			testSequence,
+		),
+		test.Instrument(
+			cntr1.inst.descriptor,
+		),
+		test.Instrument(
+			cntr2.inst.descriptor,
+		),
+	)
+}
+
+func TestCallbackDroppedInstrument(t *testing.T) {
+	errors := test.OTelErrors()
+
+	tt := testAsync("test",
+		view.WithClause(
+			view.MatchInstrumentName("drop"),
+			view.WithAggregation(aggregation.DropKind),
+		),
+	)
+
+	cntrDrop := testObserver[float64, number.Float64Traits](tt, "drop", sdkinstrument.CounterObserverKind)
+	cntrKeep := testObserver[float64, number.Float64Traits](tt, "keep", sdkinstrument.CounterObserverKind)
+
+	cb, _ := NewCallback([]instrument.Asynchronous{cntrKeep}, tt, func(ctx context.Context) {
+		cntrDrop.Observe(ctx, 1000)
+		cntrKeep.Observe(ctx, 1000)
+	})
+
+	state := testState()
+
+	cb.Run(context.Background(), state)
+
+	cntrKeep.inst.SnapshotAndProcess(state)
+	cntrDrop.inst.SnapshotAndProcess(state)
+
+	require.Equal(t, 1, len(*errors))
+	require.Contains(t, (*errors)[0].Error(), "instrument not declared for use in callback")
+
+	test.RequireEqualMetrics(
+		t,
+		test.CollectScope(
+			t,
+			tt.compiler.Collectors(),
+			testSequence,
+		),
+		test.Instrument(
+			cntrKeep.inst.descriptor,
+			test.Point(startTime, endTime, sum.NewMonotonicFloat64(1000), aggregation.CumulativeTemporality),
+		),
+	)
+}
+
+func TestInstrumentUseOutsideCallback(t *testing.T) {
+	errors := test.OTelErrors()
+
+	tt := testAsync("test")
+
+	cntr := testObserver[float64, number.Float64Traits](tt, "cntr", sdkinstrument.CounterObserverKind)
+
+	cntr.Observe(context.Background(), 1000)
+
+	state := testState()
+
+	cntr.inst.SnapshotAndProcess(state)
+
+	require.Equal(t, 1, len(*errors))
+	require.Contains(t, (*errors)[0].Error(), "async instrument used outside of callback")
+
+	test.RequireEqualMetrics(
+		t,
+		test.CollectScope(
+			t,
+			tt.compiler.Collectors(),
+			testSequence,
+		),
+		test.Instrument(
+			cntr.inst.descriptor,
+		),
+	)
+}

--- a/lightstep/sdk/metric/internal/asyncstate/callback.go
+++ b/lightstep/sdk/metric/internal/asyncstate/callback.go
@@ -1,0 +1,102 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package asyncstate // import "github.com/lightstep/otel-launcher-go/lightstep/sdk/metric/internal/asyncstate"
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	"go.opentelemetry.io/otel/metric/instrument"
+)
+
+// Callback is the implementation object associated with one
+// asynchronous callback.
+type Callback struct {
+	// function is the user-provided callback function.
+	function func(context.Context)
+
+	// instruments are the instruments permitted to be
+	// used inside this callback.
+	instruments map[*Instrument]struct{}
+}
+
+// NewCallback returns a new Callback; this checks that each of the
+// provided instruments belongs to the same meter provider.
+func NewCallback(instruments []instrument.Asynchronous, opaque interface{}, function func(context.Context)) (*Callback, error) {
+	if len(instruments) == 0 {
+		return nil, fmt.Errorf("asynchronous callback without instruments")
+	}
+	if function == nil {
+		return nil, fmt.Errorf("asynchronous callback with nil function")
+	}
+
+	cb := &Callback{
+		function:    function,
+		instruments: map[*Instrument]struct{}{},
+	}
+
+	for _, inst := range instruments {
+		ai, ok := inst.(memberInstrument)
+		if !ok {
+			return nil, fmt.Errorf("asynchronous instrument does not belong to this SDK: %T", inst)
+		}
+		thisInst := ai.instrument()
+		if thisInst.opaque != opaque {
+			return nil, fmt.Errorf("asynchronous instrument belongs to a different meter")
+		}
+
+		cb.instruments[thisInst] = struct{}{}
+	}
+
+	return cb, nil
+}
+
+// Run executes the callback after setting up the appropriate context
+// for a specific reader.
+func (c *Callback) Run(ctx context.Context, state *State) {
+	cp := &callbackState{
+		callback: c,
+		state:    state,
+	}
+	c.function(context.WithValue(ctx, contextKey{}, cp))
+	cp.invalidate()
+}
+
+// callbackState is used to lookup the current callback and
+// pipeline from within an executing callback function.
+type callbackState struct {
+	// lock protects callback, see invalidate() and getCallback()
+	lock sync.Mutex
+
+	// callback is the currently running callback; this is set to nil
+	// after the associated callback function returns.
+	callback *Callback
+
+	// state is a single collection of data.
+	state *State
+}
+
+func (cp *callbackState) invalidate() {
+	cp.lock.Lock()
+	defer cp.lock.Unlock()
+	cp.callback = nil
+}
+
+func (cp *callbackState) getCallback() *Callback {
+	cp.lock.Lock()
+	defer cp.lock.Unlock()
+	return cp.callback
+}

--- a/lightstep/sdk/metric/internal/asyncstate/observer.go
+++ b/lightstep/sdk/metric/internal/asyncstate/observer.go
@@ -1,0 +1,66 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package asyncstate // import "github.com/lightstep/otel-launcher-go/lightstep/sdk/metric/internal/asyncstate"
+
+import (
+	"context"
+
+	"github.com/lightstep/otel-launcher-go/lightstep/sdk/metric/number"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric/instrument"
+	"go.opentelemetry.io/otel/metric/instrument/asyncfloat64"
+	"go.opentelemetry.io/otel/metric/instrument/asyncint64"
+)
+
+// Observer is a generic (int64 or float64) instrument which
+// satisfies any of the asynchronous instrument API interfaces.
+type Observer[N number.Any, Traits number.Traits[N]] struct {
+	instrument.Asynchronous // Note: wasted space
+
+	inst *Instrument
+}
+
+// Observer implements 6 instruments and memberInstrument.
+var (
+	_ asyncint64.Counter       = Observer[int64, number.Int64Traits]{}
+	_ asyncint64.UpDownCounter = Observer[int64, number.Int64Traits]{}
+	_ asyncint64.Gauge         = Observer[int64, number.Int64Traits]{}
+	_ memberInstrument         = Observer[int64, number.Int64Traits]{}
+
+	_ asyncfloat64.Counter       = Observer[float64, number.Float64Traits]{}
+	_ asyncfloat64.UpDownCounter = Observer[float64, number.Float64Traits]{}
+	_ asyncfloat64.Gauge         = Observer[float64, number.Float64Traits]{}
+	_ memberInstrument           = Observer[float64, number.Float64Traits]{}
+)
+
+// memberInstrument indicates whether a user-provided
+// instrument was returned by this SDK.
+type memberInstrument interface {
+	instrument() *Instrument
+}
+
+// NewObserver returns an generic value suitable for use as any of the
+// asynchronous instrument APIs.
+func NewObserver[N number.Any, Traits number.Traits[N]](inst *Instrument) Observer[N, Traits] {
+	return Observer[N, Traits]{inst: inst}
+}
+
+func (o Observer[N, Traits]) instrument() *Instrument {
+	return o.inst
+}
+
+func (o Observer[N, Traits]) Observe(ctx context.Context, value N, attrs ...attribute.KeyValue) {
+	capture[N, Traits](ctx, o.inst, value, attrs)
+}

--- a/lightstep/sdk/metric/internal/syncstate/counter.go
+++ b/lightstep/sdk/metric/internal/syncstate/counter.go
@@ -1,0 +1,50 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package syncstate // import "github.com/lightstep/otel-launcher-go/lightstep/sdk/metric/internal/syncstate"
+
+import (
+	"context"
+
+	"github.com/lightstep/otel-launcher-go/lightstep/sdk/metric/number"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric/instrument"
+	"go.opentelemetry.io/otel/metric/instrument/syncfloat64"
+	"go.opentelemetry.io/otel/metric/instrument/syncint64"
+)
+
+// Counter is a synchronous instrument having an Add() method.
+type Counter[N number.Any, Traits number.Traits[N]] struct {
+	instrument.Synchronous // Note: wasted space
+
+	inst *Instrument
+}
+
+// Counter satisfies 4 instrument APIs.
+var (
+	_ syncint64.Counter         = Counter[int64, number.Int64Traits]{}
+	_ syncint64.UpDownCounter   = Counter[int64, number.Int64Traits]{}
+	_ syncfloat64.Counter       = Counter[float64, number.Float64Traits]{}
+	_ syncfloat64.UpDownCounter = Counter[float64, number.Float64Traits]{}
+)
+
+// NewCounter returns a value that implements the Counter and UpDownCounter APIs.
+func NewCounter[N number.Any, Traits number.Traits[N]](inst *Instrument) Counter[N, Traits] {
+	return Counter[N, Traits]{inst: inst}
+}
+
+// Add increments a Counter or UpDownCounter.
+func (c Counter[N, Traits]) Add(ctx context.Context, incr N, attrs ...attribute.KeyValue) {
+	capture[N, Traits](ctx, c.inst, incr, attrs)
+}

--- a/lightstep/sdk/metric/internal/syncstate/histogram.go
+++ b/lightstep/sdk/metric/internal/syncstate/histogram.go
@@ -1,0 +1,48 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package syncstate // import "github.com/lightstep/otel-launcher-go/lightstep/sdk/metric/internal/syncstate"
+
+import (
+	"context"
+
+	"github.com/lightstep/otel-launcher-go/lightstep/sdk/metric/number"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric/instrument"
+	"go.opentelemetry.io/otel/metric/instrument/syncfloat64"
+	"go.opentelemetry.io/otel/metric/instrument/syncint64"
+)
+
+// Histogram is a synchronous instrument having a Record() method.
+type Histogram[N number.Any, Traits number.Traits[N]] struct {
+	instrument.Synchronous // Note: wasted space
+
+	inst *Instrument
+}
+
+// Histogram satisfies 2 instrument APIs.
+var (
+	_ syncint64.Histogram   = Histogram[int64, number.Int64Traits]{}
+	_ syncfloat64.Histogram = Histogram[float64, number.Float64Traits]{}
+)
+
+// NewCounter returns a value that implements the Histogram API.
+func NewHistogram[N number.Any, Traits number.Traits[N]](inst *Instrument) Histogram[N, Traits] {
+	return Histogram[N, Traits]{inst: inst}
+}
+
+// Record records a Histogram observation.
+func (h Histogram[N, Traits]) Record(ctx context.Context, incr N, attrs ...attribute.KeyValue) {
+	capture[N, Traits](ctx, h.inst, incr, attrs)
+}

--- a/lightstep/sdk/metric/internal/syncstate/refcount_mapped.go
+++ b/lightstep/sdk/metric/internal/syncstate/refcount_mapped.go
@@ -1,0 +1,59 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package syncstate
+
+import (
+	"sync/atomic"
+)
+
+// refcountMapped atomically counts the number of references (usages) of an entry
+// while also keeping a state of mapped/unmapped into a different data structure
+// (an external map or list for example).
+//
+// refcountMapped uses an atomic value where the least significant bit is used to
+// keep the state of mapping ('1' is used for unmapped and '0' is for mapped) and
+// the rest of the bits are used for refcounting.
+type refcountMapped struct {
+	// refcount has to be aligned for 64-bit atomic operations.
+	value int64
+}
+
+// ref returns true if the entry is still mapped and increases the
+// reference usages, if unmapped returns false.
+func (rm *refcountMapped) ref() bool {
+	// Check if this entry was marked as unmapped between the moment
+	// we got a reference to it (or will be removed very soon) and here.
+	return atomic.AddInt64(&rm.value, 2)&1 == 0
+}
+
+func (rm *refcountMapped) unref() {
+	atomic.AddInt64(&rm.value, -2)
+}
+
+// tryUnmap flips the mapped bit to "unmapped" state and returns true if both of the
+// following conditions are true upon entry to this function:
+//  * There are no active references;
+//  * The mapped bit is in "mapped" state.
+// Otherwise no changes are done to mapped bit and false is returned.
+func (rm *refcountMapped) tryUnmap() bool {
+	if atomic.LoadInt64(&rm.value) != 0 {
+		return false
+	}
+	return atomic.CompareAndSwapInt64(
+		&rm.value,
+		0,
+		1,
+	)
+}

--- a/lightstep/sdk/metric/internal/syncstate/sync.go
+++ b/lightstep/sdk/metric/internal/syncstate/sync.go
@@ -1,0 +1,189 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package syncstate
+
+import (
+	"context"
+	"runtime"
+	"sync"
+	"sync/atomic"
+
+	"go.opentelemetry.io/otel/attribute"
+	"github.com/lightstep/otel-launcher-go/lightstep/sdk/metric/internal/pipeline"
+	"github.com/lightstep/otel-launcher-go/lightstep/sdk/metric/internal/viewstate"
+	"github.com/lightstep/otel-launcher-go/lightstep/sdk/metric/number"
+	"github.com/lightstep/otel-launcher-go/lightstep/sdk/metric/sdkinstrument"
+)
+
+// Instrument maintains a mapping from attribute.Set to an internal
+// record type for a single API-level instrument.  This type is
+// organized so that a single attribute.Set lookup is performed
+// regardless of the number of reader and instrument-view behaviors.
+// Entries in the map have their accumulator's SnapshotAndProcess()
+// method called whenever they are removed from the map, which can
+// happen when any reader collects the instrument.
+type Instrument struct {
+	// descriptor is the API-provided descriptor for the
+	// instrument, unmodified by views.
+	descriptor sdkinstrument.Descriptor
+
+	// compiled will be a single compiled instrument or a
+	// multi-instrument in case of multiple view behaviors
+	// and/or readers; these distinctions do not matter
+	// for synchronous aggregation.
+	compiled viewstate.Instrument
+
+	// current is a synchronous form of map[attribute.Set]*record.
+	current sync.Map
+}
+
+// NewInstruments builds a new synchronous instrument given the
+// per-pipeline instrument-views compiled.  Note that the unused
+// second parameter is an opaque value used in the asyncstate package,
+// passed here to make these two packages generalize.
+func NewInstrument(desc sdkinstrument.Descriptor, _ interface{}, compiled pipeline.Register[viewstate.Instrument]) *Instrument {
+	return &Instrument{
+		descriptor: desc,
+
+		// Note that viewstate.Combine is used to eliminate
+		// the per-pipeline distinction that is useful in the
+		// asyncstate package.  Here, in the common case there
+		// will be one pipeline and one view, such that
+		// viewstate.Combine produces a single concrete
+		// viewstate.Instrument.  Only when there are multiple
+		// views or multiple pipelines will the combination
+		// produce a viewstate.multiInstrment here.
+		compiled: viewstate.Combine(desc, compiled...),
+	}
+}
+
+// SnapshotAndProcess calls SnapshotAndProcess() for all live
+// accumulators of this instrument.  Inactive accumulators will be
+// subsequently removed from the map.
+func (inst *Instrument) SnapshotAndProcess() {
+	inst.current.Range(func(key interface{}, value interface{}) bool {
+		rec := value.(*record)
+		if rec.snapshotAndProcess() {
+			return true
+		}
+		// Having no updates since last collection, try to unmap:
+		if unmapped := rec.refMapped.tryUnmap(); !unmapped {
+			// The record is still referenced, continue.
+			return true
+		}
+
+		// If any other goroutines are now trying to re-insert this
+		// entry in the map, they are busy calling Gosched() awaiting
+		// this deletion:
+		inst.current.Delete(key)
+
+		// Last we'll see of this.
+		_ = rec.snapshotAndProcess()
+		return true
+	})
+}
+
+// record consists of an accumulator, a reference count, the number of
+// updates, and the number of collected updates.
+type record struct {
+	refMapped refcountMapped
+
+	// updateCount is incremented on every Update.
+	updateCount int64
+
+	// collectedCount is set to updateCount on collection,
+	// supports checking for no updates during a round.
+	collectedCount int64
+
+	// accumulator is can be a multi-accumulator if there
+	// are multiple behaviors or multiple readers, but
+	// these distinctions are not relevant for synchronous
+	// instruments.
+	accumulator viewstate.Accumulator
+}
+
+// snapshotAndProcessRecord checks whether the accumulator has been
+// modified since the last collection (by any reader), returns a
+// boolean indicating whether the record is active.  If active, calls
+// SnapshotAndProcess on the associated accumulator and returns true.
+// If updates happened since the last collection (by any reader),
+// returns false.
+func (rec *record) snapshotAndProcess() bool {
+	mods := atomic.LoadInt64(&rec.updateCount)
+	coll := rec.collectedCount
+
+	if mods == coll {
+		return false
+	}
+	// Updates happened in this interval, collect and continue.
+	rec.collectedCount = mods
+
+	rec.accumulator.SnapshotAndProcess()
+	return true
+}
+
+// capture performs a single update for any synchronous instrument.
+func capture[N number.Any, Traits number.Traits[N]](_ context.Context, inst *Instrument, num N, attrs []attribute.KeyValue) {
+	if inst.compiled == nil {
+		return
+	}
+
+	// Note: Here, this is the place to use context, e.g., extract baggage.
+
+	rec, updater := acquireRecord[N](inst, attrs)
+	defer rec.refMapped.unref()
+
+	updater.Update(num)
+
+	// Record was modified.
+	atomic.AddInt64(&rec.updateCount, 1)
+}
+
+// acquireRecord gets or creates a `*record` corresponding to `attrs`,
+// the input attributes.
+func acquireRecord[N number.Any](inst *Instrument, attrs []attribute.KeyValue) (*record, viewstate.Updater[N]) {
+	aset := attribute.NewSet(attrs...)
+	if lookup, ok := inst.current.Load(aset); ok {
+		// Existing record case.
+		rec := lookup.(*record)
+
+		if rec.refMapped.ref() {
+			// At this moment it is guaranteed that the
+			// record is in the map and will not be removed.
+			return rec, rec.accumulator.(viewstate.Updater[N])
+		}
+		// This record is no longer mapped, try to add a new
+		// record below.
+	}
+
+	newRec := &record{
+		refMapped: refcountMapped{value: 2},
+	}
+
+	for {
+		if found, loaded := inst.current.LoadOrStore(aset, newRec); loaded {
+			oldRec := found.(*record)
+			if oldRec.refMapped.ref() {
+				return oldRec, oldRec.accumulator.(viewstate.Updater[N])
+			}
+			runtime.Gosched()
+			continue
+		}
+		break
+	}
+
+	newRec.accumulator = inst.compiled.NewAccumulator(aset)
+	return newRec, newRec.accumulator.(viewstate.Updater[N])
+}


### PR DESCRIPTION
Description:
The internal/syncstate and internal/asyncstate package contain the adapters used by the MeterProvider to the viewstate package's compiler. The syncstate package, in particular, handles the hot code path used by synchronous instruments.

Link to tracking Issue:
LS-29760 describes the overall goal; this is one part.

Testing:
End-to-end testing was done. The alt_metrics_sdk/development branch has a assembled copy of this code. Depends on various Lightstep-side PRs merging to see the exponential histograms work.