### PR TITLE
MinMaxSumCount aggregator support LS-30446

### DIFF
--- a/lightstep/sdk/metric/aggregator/aggregation/aggregation.go
+++ b/lightstep/sdk/metric/aggregator/aggregation/aggregation.go
@@ -74,6 +74,16 @@ type (
 		Len() uint32
 		At(uint32) uint64
 	}
+
+	// MinMaxSumCount is a low cost HistogramCategory aggregator
+	// that records the Min, Max, Sum, and Count.
+	MinMaxSumCount interface {
+		Aggregation
+		Count() uint64
+		HasASum
+		Min() number.Number
+		Max() number.Number
+	}
 )
 
 // Category constants describe semantic kind.  For the histogram
@@ -99,6 +109,7 @@ const (
 	NonMonotonicSumKind
 	GaugeKind
 	HistogramKind
+	MinMaxSumCountKind
 )
 
 func (k Kind) Category(ik sdkinstrument.Kind) Category {
@@ -117,7 +128,7 @@ func (k Kind) Category(ik sdkinstrument.Kind) Category {
 		return NonMonotonicSumCategory
 	case GaugeKind:
 		return GaugeCategory
-	case HistogramKind:
+	case HistogramKind, MinMaxSumCountKind:
 		return HistogramCategory
 	default:
 		return UndefinedCategory

--- a/lightstep/sdk/metric/aggregator/minmaxsumcount/minmaxsumcount.go
+++ b/lightstep/sdk/metric/aggregator/minmaxsumcount/minmaxsumcount.go
@@ -1,0 +1,183 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package minmaxsumcount // import "github.com/lightstep/otel-launcher-go/lightstep/sdk/metric/aggregator/minmaxsumcount"
+
+import (
+	"sync"
+
+	"github.com/lightstep/otel-launcher-go/lightstep/sdk/metric/aggregator"
+	"github.com/lightstep/otel-launcher-go/lightstep/sdk/metric/aggregator/aggregation"
+	"github.com/lightstep/otel-launcher-go/lightstep/sdk/metric/number"
+)
+
+// Note: there is no checking for negative inputs here.  We assume
+// that the Histogram API contract is being met and that no negative
+// values arrive, even though the data model allows for Sum to be
+// absent when negative values are used.  IMO the Histogram data point
+// should carry information about the nature of the underlying
+// observation: a histogram of counter values has a monotonic sum; a
+// histogram of UpDownCounter and Gauge values has a non-monotonic
+// sum.
+
+type (
+	Methods[N number.Any, Traits number.Traits[N], Storage State[N, Traits]] struct{}
+
+	fields[N number.Any, Traits number.Traits[N]] struct {
+		min   N
+		max   N
+		sum   N
+		count uint64
+	}
+
+	State[N number.Any, Traits number.Traits[N]] struct {
+		lock sync.Mutex
+		fields[N, Traits]
+	}
+
+	Int64   = State[int64, number.Int64Traits]
+	Float64 = State[float64, number.Float64Traits]
+
+	Int64Methods   = Methods[int64, number.Int64Traits, Int64]
+	Float64Methods = Methods[float64, number.Float64Traits, Float64]
+)
+
+var (
+	_ aggregator.Methods[int64, Int64]     = Int64Methods{}
+	_ aggregator.Methods[float64, Float64] = Float64Methods{}
+
+	_ aggregation.MinMaxSumCount = &Int64{}
+	_ aggregation.MinMaxSumCount = &Float64{}
+)
+
+func NewInt64(vals ...int64) *Int64 {
+	a := &Int64{}
+	for _, val := range vals {
+		Int64Methods{}.Update(a, val)
+	}
+	return a
+}
+
+func NewFloat64(vals ...float64) *Float64 {
+	a := &Float64{}
+	for _, val := range vals {
+		Float64Methods{}.Update(a, val)
+	}
+	return a
+}
+
+func (g *State[N, Traits]) Sum() number.Number {
+	var t Traits
+	return t.ToNumber(g.sum)
+}
+
+func (g *State[N, Traits]) Count() uint64 {
+	return g.count
+}
+
+func (g *State[N, Traits]) Min() number.Number {
+	var t Traits
+	return t.ToNumber(g.min)
+}
+
+func (g *State[N, Traits]) Max() number.Number {
+	var t Traits
+	return t.ToNumber(g.max)
+}
+
+func (g *State[N, Traits]) Kind() aggregation.Kind {
+	return aggregation.MinMaxSumCountKind
+}
+
+func (Methods[N, Traits, Storage]) Kind() aggregation.Kind {
+	return aggregation.MinMaxSumCountKind
+}
+
+func (Methods[N, Traits, Storage]) Init(state *State[N, Traits], _ aggregator.Config) {
+}
+
+func (Methods[N, Traits, Storage]) HasChange(ptr *State[N, Traits]) bool {
+	return ptr.count != 0
+}
+
+func (Methods[N, Traits, Storage]) Move(from, to *State[N, Traits]) {
+	from.lock.Lock()
+	defer from.lock.Unlock()
+
+	to.fields, from.fields = from.fields, fields[N, Traits]{}
+}
+
+func (Methods[N, Traits, Storage]) Copy(from, to *State[N, Traits]) {
+	from.lock.Lock()
+	defer from.lock.Unlock()
+
+	to.fields = from.fields
+}
+
+func (Methods[N, Traits, Storage]) Update(state *State[N, Traits], number N) {
+	state.lock.Lock()
+	defer state.lock.Unlock()
+
+	if state.count == 0 {
+		state.min = number
+		state.max = number
+	} else {
+		if number < state.min {
+			state.min = number
+		}
+		if number > state.max {
+			state.max = number
+		}
+	}
+
+	state.sum += number
+	state.count++
+}
+
+func (Methods[N, Traits, Storage]) Merge(from, to *State[N, Traits]) {
+	to.lock.Lock()
+	defer to.lock.Unlock()
+
+	if from.fields.count != 0 {
+		if to.fields.count == 0 {
+			to.fields.min = from.fields.min
+			to.fields.max = from.fields.max
+		} else {
+			if from.fields.min < to.fields.min {
+				to.fields.min = from.fields.min
+			}
+			if from.fields.max > to.fields.max {
+				to.fields.max = from.fields.max
+			}
+		}
+	}
+
+	to.fields.sum += from.fields.sum
+	to.fields.count += from.fields.count
+}
+
+func (Methods[N, Traits, Storage]) ToAggregation(state *State[N, Traits]) aggregation.Aggregation {
+	return state
+}
+
+func (Methods[N, Traits, Storage]) ToStorage(aggr aggregation.Aggregation) (*State[N, Traits], bool) {
+	r, ok := aggr.(*State[N, Traits])
+	return r, ok
+}
+
+func (Methods[N, Traits, Storage]) SubtractSwap(operand, argument *State[N, Traits]) {
+	// This can't be called b/c histogram's are only used with synchronous instruments,
+	// which start as delta temporality and thus never subtract.
+	panic("impossible call")
+}

--- a/lightstep/sdk/metric/aggregator/minmaxsumcount/minmaxsumcount_test.go
+++ b/lightstep/sdk/metric/aggregator/minmaxsumcount/minmaxsumcount_test.go
@@ -1,0 +1,104 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package minmaxsumcount // import "github.com/lightstep/otel-launcher-go/lightstep/sdk/metric/aggregator/minmaxsumcount"
+
+import (
+	"testing"
+
+	"github.com/lightstep/otel-launcher-go/lightstep/sdk/metric/aggregator"
+	"github.com/lightstep/otel-launcher-go/lightstep/sdk/metric/aggregator/aggregation"
+	"github.com/lightstep/otel-launcher-go/lightstep/sdk/metric/aggregator/test"
+	"github.com/lightstep/otel-launcher-go/lightstep/sdk/metric/number"
+	"github.com/stretchr/testify/require"
+)
+
+func TestInt64Minmaxsumcount(t *testing.T) {
+	test.GenericAggregatorTest[int64, Int64, Int64Methods](t, number.ToInt64)
+}
+
+func TestFloat64Minmaxsumcount(t *testing.T) {
+	test.GenericAggregatorTest[float64, Float64, Float64Methods](t, number.ToFloat64)
+}
+
+func TestLastValue(t *testing.T) {
+	genericMinMaxSumCountTest[float64, Float64, Float64Methods](t, number.ToFloat64)
+	genericMinMaxSumCountTest[int64, Int64, Int64Methods](t, number.ToInt64)
+}
+
+func genericMinMaxSumCountTest[N number.Any, Storage any, Methods aggregator.Methods[N, Storage]](t *testing.T, nf func(number.Number) N) {
+	var methods Methods
+	init := func(vals ...N) *Storage {
+		var s Storage
+		methods.Init(&s, aggregator.Config{})
+		for _, val := range vals {
+			methods.Update(&s, val)
+		}
+		return &s
+	}
+
+	t.Run("correct", func(t *testing.T) {
+		in := init(3, 1, 10, 20, 500)
+		agg := methods.ToAggregation(in).(aggregation.MinMaxSumCount)
+
+		require.Equal(t, N(500), nf(agg.Max()))
+		require.Equal(t, N(1), nf(agg.Min()))
+		require.Equal(t, N(534), nf(agg.Sum()))
+		require.Equal(t, uint64(5), agg.Count())
+	})
+
+	t.Run("copy", func(t *testing.T) {
+		in := init(1, 2, 3)
+		out := init()
+		methods.Update(in, 4)
+		methods.Copy(in, out)
+
+		require.Equal(t, in, out)
+	})
+
+	t.Run("merge", func(t *testing.T) {
+		first := init(1, 2, 3)
+		second := init(4, 5, 6)
+
+		methods.Update(first, 7)
+		methods.Update(second, 8)
+
+		expect := init(1, 2, 3, 4, 5, 6, 7, 8)
+
+		methods.Merge(first, second)
+
+		require.Equal(t, expect, second)
+	})
+
+	t.Run("merge_empty_1", func(t *testing.T) {
+		first := init()
+		second := init(4)
+
+		expect := init(4)
+
+		methods.Merge(first, second)
+		require.Equal(t, expect, second)
+	})
+
+	t.Run("merge_empty_2", func(t *testing.T) {
+		first := init(4)
+		second := init()
+
+		expect := init(4)
+
+		methods.Merge(first, second)
+		require.Equal(t, expect, second)
+	})
+
+}

--- a/lightstep/sdk/metric/aggregator/test/test.go
+++ b/lightstep/sdk/metric/aggregator/test/test.go
@@ -26,6 +26,11 @@ func GenericAggregatorTest[N number.Any, Storage any, Methods aggregator.Methods
 			require.Equal(t, N(0), nf(h.Sum()))
 		} else if s, ok := agg.(aggregation.Sum); ok {
 			require.Equal(t, N(0), nf(s.Sum()))
+		} else if mmsc, ok := agg.(aggregation.MinMaxSumCount); ok {
+			require.Equal(t, N(0), nf(mmsc.Sum()))
+			require.Equal(t, N(0), nf(mmsc.Min()))
+			require.Equal(t, N(0), nf(mmsc.Max()))
+			require.Equal(t, uint64(0), mmsc.Count())
 		} else {
 			t.Fail()
 		}

--- a/lightstep/sdk/metric/exporters/otlp/internal/metrictransform/metric.go
+++ b/lightstep/sdk/metric/exporters/otlp/internal/metrictransform/metric.go
@@ -102,6 +102,13 @@ func Metrics(metrics data.Metrics) (*metricspb.ResourceMetrics, error) {
 						DataPoints: NumberPoints(&inst.Descriptor, inst.Points, gaugeToValue),
 					},
 				}
+			case aggregation.MinMaxSumCountKind:
+				mm.Data = &metricspb.Metric_Histogram{
+					Histogram: &metricspb.Histogram{
+						AggregationTemporality: Temporality(point0.Temporality),
+						DataPoints:             MinMaxSumCountPoints(&inst.Descriptor, inst.Points, point0.Temporality),
+					},
+				}
 			default:
 				return nil, ErrUnimplementedAgg
 			}
@@ -179,4 +186,36 @@ func HistogramBuckets(b aggregation.Buckets) *metricspb.ExponentialHistogramData
 		result.BucketCounts[i] = b.At(uint32(i))
 	}
 	return result
+}
+
+func float64Ptr(x float64) *float64 {
+	return &x
+}
+
+func MinMaxSumCountPoints(desc *sdkinstrument.Descriptor, points []data.Point, tempo aggregation.Temporality) []*metricspb.HistogramDataPoint {
+	results := make([]*metricspb.HistogramDataPoint, len(points))
+	for i, pt := range points {
+		mmsc := pt.Aggregation.(aggregation.MinMaxSumCount)
+
+		// See note about optional sum at top of minmaxsumcount.go
+		sum := mmsc.Sum().CoerceToFloat64(desc.NumberKind)
+
+		var min, max *float64
+
+		if mmsc.Count() != 0 {
+			min = float64Ptr(mmsc.Min().CoerceToFloat64(desc.NumberKind))
+			max = float64Ptr(mmsc.Max().CoerceToFloat64(desc.NumberKind))
+		}
+
+		results[i] = &metricspb.HistogramDataPoint{
+			Attributes:        Attributes(pt.Attributes),
+			StartTimeUnixNano: toNanos(pt.Start),
+			TimeUnixNano:      toNanos(pt.End),
+			Count:             mmsc.Count(),
+			Sum:               &sum,
+			Min:               min,
+			Max:               max,
+		}
+	}
+	return results
 }

--- a/lightstep/sdk/metric/exporters/otlp/internal/metrictransform/metric_test.go
+++ b/lightstep/sdk/metric/exporters/otlp/internal/metrictransform/metric_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/lightstep/otel-launcher-go/lightstep/sdk/metric/aggregator/aggregation"
 	"github.com/lightstep/otel-launcher-go/lightstep/sdk/metric/aggregator/gauge"
 	"github.com/lightstep/otel-launcher-go/lightstep/sdk/metric/aggregator/histogram"
+	"github.com/lightstep/otel-launcher-go/lightstep/sdk/metric/aggregator/minmaxsumcount"
 	"github.com/lightstep/otel-launcher-go/lightstep/sdk/metric/aggregator/sum"
 	"github.com/lightstep/otel-launcher-go/lightstep/sdk/metric/data"
 	"github.com/lightstep/otel-launcher-go/lightstep/sdk/metric/exporters/otlp/internal/otlptest"
@@ -274,6 +275,78 @@ func TestMetricTransform(t *testing.T) {
 				// Note: there is no attempt to avoid a scope w/ 0 instruments
 				otlptest.ScopeMetrics(
 					expectScope0,
+				),
+			),
+		},
+		// minmaxsumcount w/ ints
+		{
+			input: test.Metrics(
+				testResource1,
+				test.Scope(
+					testScope0,
+					test.Instrument(
+						testInt64(),
+						test.Point(
+							startTime,
+							endTime,
+							minmaxsumcount.NewInt64(3, 2, 4, 1, 5),
+							testCumulative,
+							testAttrs1...,
+						),
+					),
+				),
+			),
+			encoded: otlptest.ResourceMetrics(
+				expectResource1,
+				noSchema,
+				otlptest.ScopeMetrics(
+					expectScope0,
+					otlptest.MinMaxSumCount(
+						testName,
+						testDesc,
+						testUnit,
+						expectCumulative,
+						otlptest.MinMaxSumCountDataPoint(
+							expectAttrs1, startTime, endTime,
+							15, 5, 1, 5,
+						),
+					),
+				),
+			),
+		},
+		// minmaxsumcount empty with no min/max
+		{
+			input: test.Metrics(
+				testResource1,
+				test.Scope(
+					testScope0,
+					test.Instrument(
+						testInt64(),
+						test.Point(
+							startTime,
+							endTime,
+							minmaxsumcount.NewInt64(),
+							testDelta,
+							testAttrs1...,
+						),
+					),
+				),
+			),
+			encoded: otlptest.ResourceMetrics(
+				expectResource1,
+				noSchema,
+				otlptest.ScopeMetrics(
+					expectScope0,
+					otlptest.MinMaxSumCount(
+						testName,
+						testDesc,
+						testUnit,
+						expectDelta,
+						otlptest.MinMaxSumCountDataPoint(
+							expectAttrs1, startTime, endTime,
+							0, 0, 0, 0,
+						),
+					),
 				),
 			),
 		},

--- a/lightstep/sdk/metric/exporters/otlp/internal/otlptest/otlptest.go
+++ b/lightstep/sdk/metric/exporters/otlp/internal/otlptest/otlptest.go
@@ -176,3 +176,32 @@ func Histogram(name, desc, unit string, tempo metricspb.AggregationTemporality, 
 		},
 	}
 }
+
+func MinMaxSumCountDataPoint(attributes []*commonpb.KeyValue, start, end time.Time, sum float64, count uint64, min, max float64) *metricspb.HistogramDataPoint {
+	dp := &metricspb.HistogramDataPoint{
+		Attributes:        attributes,
+		StartTimeUnixNano: toNanos(start),
+		TimeUnixNano:      toNanos(end),
+		Sum:               &sum,
+		Count:             count,
+	}
+	if count != 0 {
+		dp.Min = &min
+		dp.Max = &max
+	}
+	return dp
+}
+
+func MinMaxSumCount(name, desc, unit string, tempo metricspb.AggregationTemporality, idps ...*metricspb.HistogramDataPoint) *metricspb.Metric {
+	return &metricspb.Metric{
+		Name:        name,
+		Description: desc,
+		Unit:        unit,
+		Data: &metricspb.Metric_Histogram{
+			Histogram: &metricspb.Histogram{
+				AggregationTemporality: tempo,
+				DataPoints:             idps,
+			},
+		},
+	}
+}

--- a/lightstep/sdk/metric/internal/viewstate/viewstate.go
+++ b/lightstep/sdk/metric/internal/viewstate/viewstate.go
@@ -21,6 +21,7 @@ import (
 	"github.com/lightstep/otel-launcher-go/lightstep/sdk/metric/aggregator/aggregation"
 	"github.com/lightstep/otel-launcher-go/lightstep/sdk/metric/aggregator/gauge"
 	"github.com/lightstep/otel-launcher-go/lightstep/sdk/metric/aggregator/histogram"
+	"github.com/lightstep/otel-launcher-go/lightstep/sdk/metric/aggregator/minmaxsumcount"
 	"github.com/lightstep/otel-launcher-go/lightstep/sdk/metric/aggregator/sum"
 	"github.com/lightstep/otel-launcher-go/lightstep/sdk/metric/data"
 	"github.com/lightstep/otel-launcher-go/lightstep/sdk/metric/number"
@@ -368,13 +369,21 @@ func compileSync[N number.Any, Traits number.Traits[N]](behavior singleBehavior)
 			histogram.State[N, Traits],
 			histogram.Methods[N, Traits, histogram.State[N, Traits]],
 		](behavior)
+	case aggregation.MinMaxSumCountKind:
+		return newSyncView[
+			N,
+			minmaxsumcount.State[N, Traits],
+			minmaxsumcount.Methods[N, Traits, minmaxsumcount.State[N, Traits]],
+		](behavior)
 	case aggregation.NonMonotonicSumKind:
 		return newSyncView[
 			N,
 			sum.State[N, Traits, sum.NonMonotonic],
 			sum.Methods[N, Traits, sum.NonMonotonic, sum.State[N, Traits, sum.NonMonotonic]],
 		](behavior)
-	default: // e.g., aggregation.MonotonicSumKind
+	default:
+		fallthrough
+	case aggregation.MonotonicSumKind:
 		return newSyncView[
 			N,
 			sum.State[N, Traits, sum.Monotonic],
@@ -435,7 +444,9 @@ func compileAsync[N number.Any, Traits number.Traits[N]](behavior singleBehavior
 			sum.State[N, Traits, sum.NonMonotonic],
 			sum.Methods[N, Traits, sum.NonMonotonic, sum.State[N, Traits, sum.NonMonotonic]],
 		](behavior)
-	default: // e.g., aggregation.GaugeKind
+	default:
+		fallthrough
+	case aggregation.GaugeKind:
 		return newAsyncView[
 			N,
 			gauge.State[N, Traits],


### PR DESCRIPTION
**Description:** 
Uses the OTLP v0.17 HistogramDataPoint with 0 buckets to represent a MinMaxSumCount. This works for both delta and cumulative temporality.

**Link to tracking Issue:** 
LS-30466: This is a built-in replacement for the in-house Statsd "Summary" that currently emits 4 metrics. Another PR will perform the same translation into independent metrics in metricingest.