### PR TITLE
Synchronous gauge temporality fixes

### DIFF
--- a/lightstep/sdk/metric/aggregator/aggregation/aggregation.go
+++ b/lightstep/sdk/metric/aggregator/aggregation/aggregation.go
@@ -49,8 +49,8 @@ type (
 	Gauge interface {
 		Aggregation
 
-		// Review NOTE: Should this be LastValue() or Value()?
-		Gauge() (number.Number, bool)
+		// Gauge returns the most recently observed value.
+		Gauge() number.Number
 	}
 
 	// Histogram returns the count of events in exponential-scale

--- a/lightstep/sdk/metric/aggregator/aggregation/aggregation.go
+++ b/lightstep/sdk/metric/aggregator/aggregation/aggregation.go
@@ -50,7 +50,7 @@ type (
 		Aggregation
 
 		// Review NOTE: Should this be LastValue() or Value()?
-		Gauge() number.Number
+		Gauge() (number.Number, bool)
 	}
 
 	// Histogram returns the count of events in exponential-scale

--- a/lightstep/sdk/metric/aggregator/gauge/gauge.go
+++ b/lightstep/sdk/metric/aggregator/gauge/gauge.go
@@ -15,16 +15,27 @@
 package gauge // import "github.com/lightstep/otel-launcher-go/lightstep/sdk/metric/aggregator/gauge"
 
 import (
+	"sync"
+	"sync/atomic"
+
 	"github.com/lightstep/otel-launcher-go/lightstep/sdk/metric/aggregator"
 	"github.com/lightstep/otel-launcher-go/lightstep/sdk/metric/aggregator/aggregation"
 	"github.com/lightstep/otel-launcher-go/lightstep/sdk/metric/number"
 )
 
+// Note: this Gauge aggregator is designed to be used as a synchronous
+// aggregator.  For this, it captures monotonic sequence counter with
+// each Update, allowing the collection path to detect an unused
+// instrument as distinct from an unchanged value.  The atomic sequence
+// is unnecessary overhead for the async path.
+
 type (
 	Methods[N number.Any, Traits number.Traits[N], Storage State[N, Traits]] struct{}
 
 	State[N number.Any, Traits number.Traits[N]] struct {
+		lock  sync.Mutex
 		value N
+		seq   uint64
 	}
 
 	Int64   = State[int64, number.Int64Traits]
@@ -34,7 +45,12 @@ type (
 	Float64Methods = Methods[float64, number.Float64Traits, Float64]
 )
 
+const initialSequence uint64 = 1
+
 var (
+	// The zero sequence value indicates an unset gauge
+	sequenceVar uint64 = initialSequence
+
 	_ aggregator.Methods[int64, Int64]     = Int64Methods{}
 	_ aggregator.Methods[float64, Float64] = Float64Methods{}
 
@@ -43,20 +59,33 @@ var (
 )
 
 func NewInt64(x int64) *Int64 {
-	return &Int64{value: x}
+	return &Int64{
+		value: x,
+		seq:   initialSequence,
+	}
 }
 
 func NewFloat64(x float64) *Float64 {
-	return &Float64{value: x}
+	return &Float64{
+		value: x,
+		seq:   initialSequence,
+	}
 }
 
-func (g *State[N, Traits]) Gauge() number.Number {
+func (g *State[N, Traits]) Gauge() (number.Number, bool) {
 	var t Traits
-	return t.ToNumber(g.value)
+	return t.ToNumber(g.value), g.seq != 0
 }
 
 func (g *State[N, Traits]) Kind() aggregation.Kind {
 	return aggregation.GaugeKind
+}
+
+// SetSequenceForTesting sets the Gauge to match one of the test
+// gauges so far as its sequence number, allowing it to match exactly
+// in tests.
+func (g *State[N, Traits]) SetSequenceForTesting() {
+	g.seq = initialSequence
 }
 
 func (Methods[N, Traits, Storage]) Kind() aggregation.Kind {
@@ -68,27 +97,44 @@ func (Methods[N, Traits, Storage]) Init(state *State[N, Traits], _ aggregator.Co
 }
 
 func (Methods[N, Traits, Storage]) HasChange(ptr *State[N, Traits]) bool {
-	return ptr.value != 0
+	return ptr.seq != 0
 }
 
 func (Methods[N, Traits, Storage]) Move(from, to *State[N, Traits]) {
-	var t Traits
-	to.value = t.SwapAtomic(&from.value, 0)
+	from.lock.Lock()
+	defer from.lock.Unlock()
+
+	to.value = from.value
+	to.seq = from.seq
+
+	from.seq = 0
 }
 
 func (Methods[N, Traits, Storage]) Copy(from, to *State[N, Traits]) {
-	var t Traits
-	to.value = t.GetAtomic(&from.value)
+	from.lock.Lock()
+	defer from.lock.Unlock()
+	to.value = from.value
+	to.seq = from.seq
 }
 
 func (Methods[N, Traits, Storage]) Update(state *State[N, Traits], number N) {
-	var t Traits
-	t.SetAtomic(&state.value, number)
+	newSeq := atomic.AddUint64(&sequenceVar, 1)
+
+	state.lock.Lock()
+	defer state.lock.Unlock()
+
+	state.value = number
+	state.seq = newSeq
 }
 
 func (Methods[N, Traits, Storage]) Merge(from, to *State[N, Traits]) {
-	var t Traits
-	t.SetAtomic(&to.value, from.value)
+	to.lock.Lock()
+	defer to.lock.Unlock()
+
+	if from.seq != 0 && from.seq > to.seq {
+		to.value = from.value
+		to.seq = from.seq
+	}
 }
 
 func (Methods[N, Traits, Storage]) ToAggregation(state *State[N, Traits]) aggregation.Aggregation {
@@ -101,5 +147,5 @@ func (Methods[N, Traits, Storage]) ToStorage(aggr aggregation.Aggregation) (*Sta
 }
 
 func (Methods[N, Traits, Storage]) SubtractSwap(operand, argument *State[N, Traits]) {
-	operand.value = argument.value - operand.value
+	panic("not used for non-temporal metrics")
 }

--- a/lightstep/sdk/metric/aggregator/gauge/gauge_test.go
+++ b/lightstep/sdk/metric/aggregator/gauge/gauge_test.go
@@ -72,10 +72,8 @@ func genericLastValueTest[N number.Any, Storage any, Methods aggregator.Methods[
 
 		g, ok := methods.ToAggregation(output).(aggregation.Gauge)
 		require.True(t, ok)
-		gv, has := g.Gauge()
-		require.True(t, has)
-		require.LessOrEqual(t, N(1), nf(gv))
-		require.GreaterOrEqual(t, N(workers+1), nf(gv))
+		require.LessOrEqual(t, N(1), nf(g.Gauge()))
+		require.GreaterOrEqual(t, N(workers+1), nf(g.Gauge()))
 
 		require.True(t, methods.HasChange(output))
 		require.True(t, !methods.HasChange(input))
@@ -99,10 +97,9 @@ func genericLastValueTest[N number.Any, Storage any, Methods aggregator.Methods[
 		methods.Merge(first, second)
 
 		var methods Methods
+		require.True(t, methods.HasChange(second))
 		agg := methods.ToAggregation(second)
-		value, has := agg.(aggregation.Gauge).Gauge()
-		require.True(t, has)
-		require.Equal(t, N(23), nf(value))
+		require.Equal(t, N(23), nf(agg.(aggregation.Gauge).Gauge()))
 	})
 
 	t.Run("merge2", func(t *testing.T) {
@@ -114,9 +111,8 @@ func genericLastValueTest[N number.Any, Storage any, Methods aggregator.Methods[
 		methods.Merge(first, second)
 
 		var methods Methods
+		require.True(t, methods.HasChange(second))
 		agg := methods.ToAggregation(second)
-		value, has := agg.(aggregation.Gauge).Gauge()
-		require.True(t, has)
-		require.Equal(t, N(17), nf(value))
+		require.Equal(t, N(17), nf(agg.(aggregation.Gauge).Gauge()))
 	})
 }

--- a/lightstep/sdk/metric/aggregator/test/test.go
+++ b/lightstep/sdk/metric/aggregator/test/test.go
@@ -34,7 +34,8 @@ func GenericAggregatorTest[N number.Any, Storage any, Methods aggregator.Methods
 
 		agg := methods.ToAggregation(&storage)
 		if g, ok := agg.(aggregation.Gauge); ok {
-			require.Equal(t, N(0), nf(g.Gauge()))
+			_, has := g.Gauge()
+			require.False(t, has)
 		} else if h, ok := agg.(aggregation.Histogram); ok {
 			require.Equal(t, uint64(0), h.Count())
 			require.Equal(t, N(0), nf(h.Sum()))

--- a/lightstep/sdk/metric/aggregator/test/test.go
+++ b/lightstep/sdk/metric/aggregator/test/test.go
@@ -33,9 +33,8 @@ func GenericAggregatorTest[N number.Any, Storage any, Methods aggregator.Methods
 		methods.Init(&storage, aggregator.Config{})
 
 		agg := methods.ToAggregation(&storage)
-		if g, ok := agg.(aggregation.Gauge); ok {
-			_, has := g.Gauge()
-			require.False(t, has)
+		if _, ok := agg.(aggregation.Gauge); ok {
+			require.False(t, methods.HasChange(&storage))
 		} else if h, ok := agg.(aggregation.Histogram); ok {
 			require.Equal(t, uint64(0), h.Count())
 			require.Equal(t, N(0), nf(h.Sum()))

--- a/lightstep/sdk/metric/exporters/otlp/internal/metrictransform/metric.go
+++ b/lightstep/sdk/metric/exporters/otlp/internal/metrictransform/metric.go
@@ -119,15 +119,15 @@ func Metrics(metrics data.Metrics) (*metricspb.ResourceMetrics, error) {
 
 }
 
-func sumToValue(pt data.Point) (number.Number, bool) {
-	return pt.Aggregation.(aggregation.Sum).Sum(), true
+func sumToValue(pt data.Point) number.Number {
+	return pt.Aggregation.(aggregation.Sum).Sum()
 }
 
-func gaugeToValue(pt data.Point) (number.Number, bool) {
+func gaugeToValue(pt data.Point) number.Number {
 	return pt.Aggregation.(aggregation.Gauge).Gauge()
 }
 
-func NumberPoints(desc *sdkinstrument.Descriptor, points []data.Point, p2v func(data.Point) (number.Number, bool)) []*metricspb.NumberDataPoint {
+func NumberPoints(desc *sdkinstrument.Descriptor, points []data.Point, p2v func(data.Point) number.Number) []*metricspb.NumberDataPoint {
 	results := make([]*metricspb.NumberDataPoint, len(points))
 	for i, pt := range points {
 		results[i] = &metricspb.NumberDataPoint{
@@ -135,10 +135,7 @@ func NumberPoints(desc *sdkinstrument.Descriptor, points []data.Point, p2v func(
 			StartTimeUnixNano: toNanos(pt.Start),
 			TimeUnixNano:      toNanos(pt.End),
 		}
-		value, has := p2v(pt)
-		if !has {
-			continue
-		}
+		value := p2v(pt)
 		if desc.NumberKind == number.Float64Kind {
 			results[i].Value = &metricspb.NumberDataPoint_AsDouble{
 				AsDouble: number.ToFloat64(value),

--- a/lightstep/sdk/metric/internal/syncstate/sync.go
+++ b/lightstep/sdk/metric/internal/syncstate/sync.go
@@ -86,25 +86,27 @@ func NewInstrument(desc sdkinstrument.Descriptor, _ interface{}, compiled pipeli
 func (inst *Instrument) SnapshotAndProcess() {
 	inst.current.Range(func(key interface{}, value interface{}) bool {
 		rec := value.(*record)
-		if rec.snapshotAndProcess(false) {
+		if rec.conditionalSnapshotAndProcess(false) {
 			return true
 		}
 		// Having no updates since last collection, try to unmap:
-		if unmapped := rec.refMapped.tryUnmap(); !unmapped {
-			// The record is still referenced, continue.
-			return true
+		unmapped := rec.refMapped.tryUnmap()
+
+		// The first rec.conditionalSnapshotAndProcess
+		// returned false indicating no change, except:
+		// (a) it's now possible there was a race, the collector needs to
+		// see it.
+		// (b) if this is indeed the last reference, the collector needs the
+		// release signal.
+		_ = rec.conditionalSnapshotAndProcess(unmapped)
+
+		if unmapped {
+			// If any other goroutines are now trying to re-insert this
+			// entry in the map, they are busy calling Gosched() awaiting
+			// this deletion:
+			inst.current.Delete(key)
 		}
 
-		// If any other goroutines are now trying to re-insert this
-		// entry in the map, they are busy calling Gosched() awaiting
-		// this deletion:
-		inst.current.Delete(key)
-
-		// We have an exclusive reference to this accumulator
-		// now, but there could have been an update between
-		// the snapshotAndProcess() and tryUnmap() above, so
-		// snapshotAndProcess one last time.
-		_ = rec.snapshotAndProcess(true)
 		return true
 	})
 }
@@ -128,20 +130,21 @@ type record struct {
 	accumulator viewstate.Accumulator
 }
 
-// snapshotAndProcess checks whether the accumulator has been
+// conditionalSnapshotAndProcess checks whether the accumulator has been
 // modified since the last collection (by any reader), returns a
 // boolean indicating whether the record is active.  If active, calls
 // SnapshotAndProcess on the associated accumulator and returns true.
 // If updates happened since the last collection (by any reader),
 // returns false.
-func (rec *record) snapshotAndProcess(final bool) bool {
+func (rec *record) conditionalSnapshotAndProcess(release bool) bool {
 	mods := atomic.LoadInt64(&rec.updateCount)
 	coll := atomic.LoadInt64(&rec.collectedCount)
 
-	if mods == coll {
+	if !release && mods == coll {
 		return false
 	}
-	rec.accumulator.SnapshotAndProcess(final)
+
+	rec.accumulator.SnapshotAndProcess(release)
 
 	// Updates happened in this interval, collect and continue.
 	atomic.StoreInt64(&rec.collectedCount, mods)

--- a/lightstep/sdk/metric/internal/syncstate/sync.go
+++ b/lightstep/sdk/metric/internal/syncstate/sync.go
@@ -138,10 +138,11 @@ type record struct {
 // returns false.
 func (rec *record) conditionalSnapshotAndProcess(release bool) bool {
 	mods := atomic.LoadInt64(&rec.updateCount)
-	coll := atomic.LoadInt64(&rec.collectedCount)
 
-	if !release && mods == coll {
-		return false
+	if !release {
+		if mods == atomic.LoadInt64(&rec.collectedCount) {
+			return false
+		}
 	}
 
 	rec.accumulator.SnapshotAndProcess(release)

--- a/lightstep/sdk/metric/internal/viewstate/accumulators.go
+++ b/lightstep/sdk/metric/internal/viewstate/accumulators.go
@@ -81,9 +81,9 @@ func (c *compiledAsyncBase[N, Storage, Methods]) findStorage(
 // multiAccumulator
 type multiAccumulator[N number.Any] []Accumulator
 
-func (a multiAccumulator[N]) SnapshotAndProcess(final bool) {
+func (a multiAccumulator[N]) SnapshotAndProcess(release bool) {
 	for _, coll := range a {
-		coll.SnapshotAndProcess(final)
+		coll.SnapshotAndProcess(release)
 	}
 }
 
@@ -108,13 +108,13 @@ func (a *syncAccumulator[N, Storage, Methods]) Update(number N) {
 	methods.Update(&a.current, number)
 }
 
-func (a *syncAccumulator[N, Storage, Methods]) SnapshotAndProcess(final bool) {
+func (a *syncAccumulator[N, Storage, Methods]) SnapshotAndProcess(release bool) {
 	var methods Methods
 	a.syncLock.Lock()
 	defer a.syncLock.Unlock()
 	methods.Move(&a.current, &a.snapshot)
 	methods.Merge(&a.snapshot, &a.holder.storage)
-	if final {
+	if release {
 		// On the final snapshot-and-process, decrement the auxiliary reference count.
 		atomic.AddInt64(&a.holder.auxiliary, -1)
 	}

--- a/lightstep/sdk/metric/internal/viewstate/collectors.go
+++ b/lightstep/sdk/metric/internal/viewstate/collectors.go
@@ -66,17 +66,25 @@ func (p *statelessSyncInstrument[N, Storage, Methods]) Collect(seq data.Sequence
 
 		cpy, _ := methods.ToStorage(point.Aggregation)
 		if !methods.HasChange(cpy) {
-			// Now  If the data is unchanged, truncate.
+			// Except for Gauge, if additive data is unchanged,
+			// truncate to avoid sending a zero.  We allowed the
+			// array to grow before this test speculatively, since
+			// when it succeeds we are able to re-use the underlying
+			// aggregator.
 			ioutput.Points = ptsArr[0 : len(ptsArr)-1 : cap(ptsArr)]
-			// If there are no more accumulators, remove from the map.
-			if atomic.LoadInt64(&entry.auxiliary) == 0 {
-				delete(p.data, set)
-			}
 		}
-		// Another design here would avoid the point before
-		// appending/truncating.  This choice uses the slice
-		// of points to store the extra allocator used, even
-		// until the next collection.
+		// If there are no more accumulators, remove from the
+		// map.  This happens when the syncstate the entry
+		// goes unused for the interval between collection, so
+		// if it happens here probably there was no change.
+		// This branch is outside the above HasChange() block
+		// in case of a race -- the entry can have a final
+		// change if it was updated after the (mods == coll)
+		// test in conditionalSnapshotAndProcess but before
+		// the entry is unmapped.
+		if atomic.LoadInt64(&entry.auxiliary) == 0 {
+			delete(p.data, set)
+		}
 	}
 }
 
@@ -108,7 +116,8 @@ type statefulAsyncInstrument[N number.Any, Storage any, Methods aggregator.Metho
 	prior map[attribute.Set]*storageHolder[Storage, notUsed]
 }
 
-// Collect for asynchronous delta temporality.
+// Collect for asynchronous delta temporality.  Note this code path is
+// not used for Gauge instruments.
 func (p *statefulAsyncInstrument[N, Storage, Methods]) Collect(seq data.Sequence, output *[]data.Instrument) {
 	var methods Methods
 
@@ -118,6 +127,7 @@ func (p *statefulAsyncInstrument[N, Storage, Methods]) Collect(seq data.Sequence
 	ioutput := p.appendInstrument(output)
 
 	for set, entry := range p.data {
+		// Compute the difference.
 		pval, has := p.prior[set]
 		if has {
 			// This does `*pval := *storage - *pval`
@@ -127,11 +137,7 @@ func (p *statefulAsyncInstrument[N, Storage, Methods]) Collect(seq data.Sequence
 			if !methods.HasChange(&pval.storage) {
 				continue
 			}
-			// Output the difference except for Gauge, in
-			// which case output the new value.
-			if p.desc.Kind.HasTemporality() {
-				entry = pval
-			}
+			entry = pval
 		}
 		p.appendPoint(ioutput, set, &entry.storage, aggregation.DeltaTemporality, seq.Last, seq.Now, false)
 	}

--- a/lightstep/sdk/metric/internal/viewstate/collectors.go
+++ b/lightstep/sdk/metric/internal/viewstate/collectors.go
@@ -66,22 +66,21 @@ func (p *statelessSyncInstrument[N, Storage, Methods]) Collect(seq data.Sequence
 
 		cpy, _ := methods.ToStorage(point.Aggregation)
 		if !methods.HasChange(cpy) {
-			// Except for Gauge, if additive data is unchanged,
-			// truncate to avoid sending a zero.  We allowed the
-			// array to grow before this test speculatively, since
-			// when it succeeds we are able to re-use the underlying
+			// We allowed the array to grow before this
+			// test speculatively, since when it succeeds
+			// we are able to re-use the underlying
 			// aggregator.
 			ioutput.Points = ptsArr[0 : len(ptsArr)-1 : cap(ptsArr)]
 		}
-		// If there are no more accumulators, remove from the
-		// map.  This happens when the syncstate the entry
-		// goes unused for the interval between collection, so
-		// if it happens here probably there was no change.
-		// This branch is outside the above HasChange() block
-		// in case of a race -- the entry can have a final
-		// change if it was updated after the (mods == coll)
-		// test in conditionalSnapshotAndProcess but before
-		// the entry is unmapped.
+		// If there are no more accumulator references to the
+		// entry, remove from the map.  This happens when the
+		// syncstate the entry goes unused for the interval
+		// between collection, so if it happens here probably
+		// there was no change.  This branch is outside the
+		// HasChange() block above in case of a race -- the
+		// entry can have a final change if it was updated
+		// after the (mods == coll) test in conditionalSnapshotAndProcess()
+		// but before the entry is unmapped.
 		if atomic.LoadInt64(&entry.auxiliary) == 0 {
 			delete(p.data, set)
 		}

--- a/lightstep/sdk/metric/internal/viewstate/viewstate_test.go
+++ b/lightstep/sdk/metric/internal/viewstate/viewstate_test.go
@@ -892,9 +892,9 @@ func TestDeltaTemporalityCounter(t *testing.T) {
 	}
 }
 
-// TestDeltaTemporalityGauge ensures that the asynchronous gauge
-// when used with delta temporalty only reports changed values.
-func TestDeltaTemporalityGauge(t *testing.T) {
+// TestDeltaTemporalityAsyncGauge ensures that the asynchronous gauge
+// disregards delta temporalty.
+func TestDeltaTemporalityAsyncGauge(t *testing.T) {
 	views := view.New(
 		"test",
 		view.WithDefaultAggregationTemporalitySelector(view.DeltaPreferredTemporality),
@@ -913,23 +913,25 @@ func TestDeltaTemporalityGauge(t *testing.T) {
 	observe := func(x int) {
 		accI := instI.NewAccumulator(set)
 		accI.(Updater[int64]).Update(int64(x))
-		accI.SnapshotAndProcess(false)
+		accI.SnapshotAndProcess(true)
 
 		accF := instF.NewAccumulator(set)
 		accF.(Updater[float64]).Update(float64(x))
-		accF.SnapshotAndProcess(false)
+		accF.SnapshotAndProcess(true)
 	}
 
+	// Note "cumulative" in each of the expected points below.  This results from
+	// disregarding the temporality preference for Gauges.
 	expectValues := func(x int, seq data.Sequence) {
 		test.RequireEqualMetrics(t,
 			testCollectSequence(t, vc, seq),
 			test.Instrument(
 				test.Descriptor("gaugeF", sdkinstrument.AsyncGauge, number.Float64Kind),
-				test.Point(seq.Last, seq.Now, gauge.NewFloat64(float64(x)), delta),
+				test.Point(seq.Start, seq.Now, gauge.NewFloat64(float64(x)), cumulative),
 			),
 			test.Instrument(
 				test.Descriptor("gaugeI", sdkinstrument.AsyncGauge, number.Int64Kind),
-				test.Point(seq.Last, seq.Now, gauge.NewInt64(int64(x)), delta),
+				test.Point(seq.Start, seq.Now, gauge.NewInt64(int64(x)), cumulative),
 			),
 		)
 	}
@@ -955,11 +957,9 @@ func TestDeltaTemporalityGauge(t *testing.T) {
 	expectValues(10, seq)
 	tick()
 
-	observe(10)
 	expectNone(seq)
 	tick()
 
-	observe(10)
 	expectNone(seq)
 	tick()
 
@@ -968,12 +968,173 @@ func TestDeltaTemporalityGauge(t *testing.T) {
 	tick()
 
 	observe(11)
+	expectValues(11, seq)
+	tick()
+
 	expectNone(seq)
 	tick()
 
-	observe(10)
+	observe(11)
+	expectValues(11, seq)
+	tick()
+}
+
+// TestDeltaTemporalitySyncGauge ensures that the _synchronous_ gauge
+// when used with delta temporalty only reports updated values.
+func TestDeltaTemporalitySyncGauge(t *testing.T) {
+	views := view.New(
+		"test",
+		view.WithDefaultAggregationTemporalitySelector(
+			func(ik sdkinstrument.Kind) aggregation.Temporality {
+				return aggregation.DeltaTemporality
+			}),
+	)
+	asGauge := instrument.WithDescription(`{
+  "aggregation": "gauge"
+}`)
+
+	vc := New(testLib, views)
+
+	instF, err := testCompile(vc, "gaugeF", sdkinstrument.SyncUpDownCounter, number.Float64Kind, asGauge)
+	require.NoError(t, err)
+
+	instI, err := testCompile(vc, "gaugeI", sdkinstrument.SyncUpDownCounter, number.Int64Kind, asGauge)
+	require.NoError(t, err)
+
+	set := attribute.NewSet()
+
+	var accI Accumulator
+	var accF Accumulator
+
+	makeAccums := func() {
+		accI = instI.NewAccumulator(set)
+		accF = instF.NewAccumulator(set)
+	}
+
+	observe := func(release bool, xs ...int) {
+		for _, x := range xs {
+			accI.(Updater[int64]).Update(int64(x))
+			accF.(Updater[float64]).Update(float64(x))
+		}
+
+		accI.SnapshotAndProcess(release)
+		accF.SnapshotAndProcess(release)
+
+		if release {
+			accI = nil
+			accF = nil
+		}
+	}
+
+	noObserve := func() {
+		accI.SnapshotAndProcess(true)
+		accF.SnapshotAndProcess(true)
+		accI = nil
+		accF = nil
+	}
+
+	expectValues := func(x int, seq data.Sequence) {
+		test.RequireEqualMetrics(t,
+			testCollectSequence(t, vc, seq),
+			test.Instrument(
+				test.Descriptor("gaugeF", sdkinstrument.SyncUpDownCounter, number.Float64Kind),
+				test.Point(seq.Last, seq.Now, gauge.NewFloat64(float64(x)), delta),
+			),
+			test.Instrument(
+				test.Descriptor("gaugeI", sdkinstrument.SyncUpDownCounter, number.Int64Kind),
+				test.Point(seq.Last, seq.Now, gauge.NewInt64(int64(x)), delta),
+			),
+		)
+	}
+	expectNone := func(seq data.Sequence) {
+		test.RequireEqualMetrics(t,
+			testCollectSequence(t, vc, seq),
+			test.Instrument(
+				test.Descriptor("gaugeF", sdkinstrument.SyncUpDownCounter, number.Float64Kind),
+			),
+			test.Instrument(
+				test.Descriptor("gaugeI", sdkinstrument.SyncUpDownCounter, number.Int64Kind),
+			),
+		)
+	}
+	seq := testSequence
+	tick := func() {
+		// Update the test sequence
+		seq.Last = seq.Now
+		seq.Now = time.Now()
+	}
+
+	compI := instI.(*statelessSyncInstrument[int64, gauge.Int64, gauge.Int64Methods])
+	compF := instF.(*statelessSyncInstrument[float64, gauge.Float64, gauge.Float64Methods])
+
+	// start with one observation, collect
+	makeAccums()
+	observe(false, 10)
 	expectValues(10, seq)
 	tick()
+	require.Equal(t, 1, len(compI.data))
+	require.Equal(t, 1, len(compF.data))
+
+	// no observation => collect releases the accumulators
+	noObserve()
+	expectNone(seq)
+	tick()
+	require.Equal(t, 0, len(compI.data))
+	require.Equal(t, 0, len(compF.data))
+
+	// new observation => new accumulators
+	makeAccums()
+	observe(false, 11)
+	expectValues(11, seq)
+	tick()
+	require.Equal(t, 1, len(compI.data))
+	require.Equal(t, 1, len(compF.data))
+
+	// observation races w/ collection, release anyway
+	observe(true, 12)
+	expectValues(12, seq)
+	tick()
+	// The release=true signal is honored, even when a final
+	// update races with the unmapping.
+	require.Equal(t, 0, len(compI.data))
+	require.Equal(t, 0, len(compF.data))
+
+	// repeat use
+	makeAccums()
+	observe(false, 10, 11, 10)
+	expectValues(10, seq)
+	tick()
+	require.Equal(t, 1, len(compI.data))
+	require.Equal(t, 1, len(compF.data))
+
+	observe(false, 11, 12, 13)
+	expectValues(13, seq)
+	tick()
+	require.Equal(t, 1, len(compI.data))
+	require.Equal(t, 1, len(compF.data))
+
+	observe(false, 9)
+	expectValues(9, seq)
+	tick()
+	require.Equal(t, 1, len(compI.data))
+	require.Equal(t, 1, len(compF.data))
+
+	// repeat no observations
+	noObserve()
+	expectNone(seq)
+	tick()
+	require.Equal(t, 0, len(compI.data))
+	require.Equal(t, 0, len(compF.data))
+
+	expectNone(seq)
+	tick()
+	require.Equal(t, 0, len(compI.data))
+	require.Equal(t, 0, len(compF.data))
+
+	expectNone(seq)
+	tick()
+	require.Equal(t, 0, len(compI.data))
+	require.Equal(t, 0, len(compF.data))
 }
 
 // TestSyncDeltaTemporalityCounter ensures that counter and updowncounter

--- a/lightstep/sdk/metric/internal/viewstate/viewstate_test.go
+++ b/lightstep/sdk/metric/internal/viewstate/viewstate_test.go
@@ -921,7 +921,7 @@ func TestDeltaTemporalityAsyncGauge(t *testing.T) {
 	}
 
 	// Note "cumulative" in each of the expected points below.  This results from
-	// disregarding the temporality preference for Gauges.
+	// disregarding the temporality preference for *asynchronous* Gauges.
 	expectValues := func(x int, seq data.Sequence) {
 		test.RequireEqualMetrics(t,
 			testCollectSequence(t, vc, seq),


### PR DESCRIPTION
**Description:** 

The Lightstep Metrics SDK has experimental support for synchronous gauges. This changes the behavior of synchronous gauges when configured with delta aggregation temporality to behave exactly as they would in a typical Statsd client. For cumulative temporality, the latest Gauge value reported will continue to report forever. For delta temporality, after this change, the latest Gauge value reported will report at most once.

Details:

The existing support in this SDK for Gauges has two under-specified behaviors. When asynchronous Gauges were configured for delta temporality, the SDK was checking for no-change-of-value and if the value was not changed it would not report the point. This changes that behavior (not specified by OTel) so that temporality settings have no impact for asynchronous gauge instruments, this makes them consistent with the synchronous Gauge behavior. If anything, it's the cumulative behavior of asynchronous gauges that is under-specified here. Should the SDK be required to track all the asynchronous Gauge values ever used so that it can report the values explicitly forgotten by the callback? Maybe, but we should let OTel specify that first. As it stands after this PR, asynchronous Gauges always report exactly the observations issued by the callback; if the callback stops reporting a value, it disappears from the output in both delta and cumulative scenarios.

This corrects a bug in the reference counting that allows the accounting work done in `internal/syncstate` to also count accumulators in use. This ensures that an SDK configured with delta temporality will not accumulate memory forever; this is now better tested. This machinery ensures the at-most-once property offered to sync/delta gauges.

The Gauge aggregator is largely rewritten here. For synchronous Gauges to report at-most-once and not accidentally report a spurious 0 at the end of the series, it needs (a) a way to tell when no value is present, (b) a way to tell which value was observed _after_ another value. The addition of a lock and a sequence number satisfies these requirements.

The API hint mechanism in this SDK is extended here so that the hint applies before any View clauses are applied. Previously, the hint was only applied when no View clauses match. This allows Views to work in conjunction with hints. Specifically this allows a View clause to restrict the Keys used by all metric instruments (by default) while still honoring the hints (this is used in a test, for example).

**Testing:** New tests are added here.

**Documentation:** These are all considered bugfixes, no new docs.