### PR TITLE
Lightstep metrics SDK: Fix race condition in sync-delta code path

### DIFF
--- a/lightstep/sdk/metric/internal/viewstate/viewstate_test.go
+++ b/lightstep/sdk/metric/internal/viewstate/viewstate_test.go
@@ -1090,14 +1090,13 @@ func TestDeltaTemporalitySyncGauge(t *testing.T) {
 	require.Equal(t, 1, len(compI.data))
 	require.Equal(t, 1, len(compF.data))
 
-	// observation races w/ collection, release anyway
+	// observation races w/ collection, release w/ active ref
 	observe(true, 12)
 	expectValues(12, seq)
 	tick()
-	// The release=true signal is honored, even when a final
-	// update races with the unmapping.
-	require.Equal(t, 0, len(compI.data))
-	require.Equal(t, 0, len(compF.data))
+
+	require.Equal(t, 1, len(compI.data))
+	require.Equal(t, 1, len(compF.data))
 
 	// repeat use
 	makeAccums()

--- a/lightstep/sdk/metric/periodic_test.go
+++ b/lightstep/sdk/metric/periodic_test.go
@@ -147,6 +147,8 @@ func TestPeriodicRepeats(t *testing.T) {
 		periodic.Register(producer)
 		periodic.Register(producer)
 
+		periodic.stop()
+
 		require.Equal(t, 1, len(*errs))
 		require.True(t, errors.Is((*errs)[0], ErrMultipleReaderRegistration))
 	})


### PR DESCRIPTION
**Description:** 
There was a race in the delta-temporality collection path for synchronous instruments when multiple readers were present. This fixes that race (and a test that was validating the bad behavior).

**Link to tracking Issue:** Fixes #204 

**Testing:** Lots of -count=1000 testing to reproduce locally what seems easy in the CI pipeline
