### PR TITLE
Increment the zero bucket using the increment multiplier

### DIFF
--- a/lightstep/sdk/metric/aggregator/histogram/structure/exponential.go
+++ b/lightstep/sdk/metric/aggregator/histogram/structure/exponential.go
@@ -285,7 +285,7 @@ func (h *Histogram[N]) UpdateByIncr(number N, incr uint64) {
 	h.count += incr
 
 	if value == 0 {
-		h.zeroCount++
+		h.zeroCount += incr
 		return
 	}
 

--- a/lightstep/sdk/metric/aggregator/histogram/structure/exponential_test.go
+++ b/lightstep/sdk/metric/aggregator/histogram/structure/exponential_test.go
@@ -736,6 +736,16 @@ func TestAggregatorCopySwap(t *testing.T) {
 	requireEqual(t, h2, h3)
 }
 
+// TestZeroCountByIncr verifies that zero counts are incremented properly.
+func TestZeroCountByIncr(t *testing.T) {
+	// 10 "0" values
+	h1 := NewFloat64(NewConfig(), 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
+	h2 := NewFloat64(NewConfig())
+	h2.UpdateByIncr(0, 10)
+
+	requireEqual(t, h1, h2)
+}
+
 // Benchmarks the Update() function for values in the range [1,2)
 func BenchmarkLinear(b *testing.B) {
 	src := rand.NewSource(77777677777)


### PR DESCRIPTION
**Description:** The UpdateByIncr() method increments the zero count bucket by 1 instead of `incr`.

**Link to tracking Issue:** Discovered while testing the OTC statsd receiver based on this code.

**Testing:** One new test added.
