### PR TITLE
Do not print empty error messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## Unreleased
 
+### 🧰 Bug fixes 🧰
+
+- Partial error handling: avoid printing spurious messages when there is no error. [#247](https://github.com/lightstep/otel-launcher-go/pull/247)
+
 ## [1.9.0](https://github.com/lightstep/otel-launcher-go/releases/tag/v1.9.0) - 2022-08-04
 
 ### 💡 Enhancements

--- a/pipelines/metrics.go
+++ b/pipelines/metrics.go
@@ -146,8 +146,12 @@ type dropSummary struct {
 	Dropped struct {
 		Points  int `json:"points,omitempty"`
 		Metrics int `json:"metrics,omitempty"`
-	} `json:"dropped"`
+	} `json:"dropped,omitempty"`
 	Examples []dropExample `json:"examples,omitempty"`
+}
+
+func (ds *dropSummary) Empty() bool {
+	return len(ds.Examples) == 0 && ds.Dropped.Points == 0 && ds.Dropped.Metrics == 0
 }
 
 func interceptor(
@@ -187,8 +191,10 @@ func interceptor(
 				})
 			}
 		}
-		data, _ := json.Marshal(ds)
-		otel.Handle(fmt.Errorf("metrics partial failure: %v", string(data)))
+		if !ds.Empty() {
+			data, _ := json.Marshal(ds)
+			otel.Handle(fmt.Errorf("metrics partial failure: %v", string(data)))
+		}
 	}
 	return err
 }


### PR DESCRIPTION
**Description:** User reported printing of partial error messages with no body.

**Testing:** New test added.
