### PR TITLE
Use the explicit histogram to avoid conflicts with Lightstep metrics SDK behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,16 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 - Partial error handling: avoid printing spurious messages when there is no error. [#247](https://github.com/lightstep/otel-launcher-go/pull/247)
 
+### Changed
+
+- Histogram instruments now select the explicit-boundary histogram for
+  the otel-go SDK, which is a breaking change for Lightstep users, but
+  as the Lightstep SDK is using exopnential histograms this is the
+  matching default which allows upgrade and downgrade between these
+  SDKs.  Users who encounter errors related to histogram instruments
+  (e.g,. `process.runtime.go.gc.pause_ns`) please contact a Lightstep
+  representative. [#249](https://github.com/lightstep/otel-launcher-go/pull/249)
+
 ## [1.9.0](https://github.com/lightstep/otel-launcher-go/releases/tag/v1.9.0) - 2022-08-04
 
 ### 💡 Enhancements

--- a/pipelines/metrics.go
+++ b/pipelines/metrics.go
@@ -98,7 +98,7 @@ func NewMetricsPipeline(c PipelineConfig) (func() error, error) {
 		}
 		sdk := controller.New(
 			processor.NewFactory(
-				selector.NewWithInexpensiveDistribution(),
+				selector.NewWithHistogramDistribution(),
 				metricExporter,
 			),
 			controller.WithExporter(metricExporter),


### PR DESCRIPTION
**Description:** Change the configuration of histogram instruments for the otel-go SDK to match the lightstep SDK's use of histogram. Otherwise, Lightstep users get a semantic conflict when they upgrade between these two. Moreover, the status quo is broken, see #248.

**Link to tracking Issue:** 
Fixes #248

**Testing:** 
Testing confirmed the hypothesis and led to https://github.com/open-telemetry/opentelemetry-go/pull/3101.
