### PR TITLE
retract 1.10.0, prepare 1.10.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,16 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## Unreleased
 
+## [1.10.1](https://github.com/lightstep/otel-launcher-go/releases/tag/v1.10.1) - 2022-08-29
+
+- Revert the default change of temporality to "cumulative" from #258.
+  New users are recommended to configure
+  `WithMetricExporterTemporalityPreference("stateless")` temporality
+  preference if possible.
+
 ## [1.10.0](https://github.com/lightstep/otel-launcher-go/releases/tag/v1.10.0) - 2022-08-28
+
+This version was retracted because of the change of temporality preference.
 
 ### 🧰 Bug fixes 🧰
 

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Additional options
 | WithSpanExporterInsecure                | OTEL_EXPORTER_OTLP_SPAN_INSECURE                 | n        | false                    |
 | WithMetricExporterEndpoint              | OTEL_EXPORTER_OTLP_METRIC_ENDPOINT               | n        | ingest.lightstep.com:443 |
 | WithMetricExporterInsecure              | OTEL_EXPORTER_OTLP_METRIC_INSECURE               | n        | false                    |
-| WithMetricExporterTemporalityPreference | OTEL_EXPORTER_OTLP_METRIC_TEMPORALITY_PREFERENCE | n        | stateless                    |
+| WithMetricExporterTemporalityPreference | OTEL_EXPORTER_OTLP_METRIC_TEMPORALITY_PREFERENCE | n        | cumulative               |
 | WithAccessToken                         | LS_ACCESS_TOKEN                                  | n        | -                        |
 | WithLogLevel                            | OTEL_LOG_LEVEL                                   | n        | info                     |
 | WithPropagators                         | OTEL_PROPAGATORS                                 | n        | b3                       |
@@ -124,19 +124,17 @@ to be maintained.  The temporality preference is configured by calling
 `OTEL_EXPORTER_OTLP_METRIC_TEMPORALITY_PREFERENCE` environment
 variable.
 
-The launcher supports an experimental "stateless" temporality
-preference.  This selection configures the ideal behavior for
-Lightstep by mixing temporality setings.  This setting uses delta
-temporality for synchronous Counter and Histogram instruments, while
-using cumulative temporality for asynchronous Counters.  Note that
-synchronous and asynchronous UpDownCounter instruments are specified
-to use cumulative temporality in OpenTelemetry metrics SDKs
-independent of the temporality preference.
+The launcher supports a "stateless" temporality preference.  This
+selection configures the ideal behavior for Lightstep by mixing
+temporality setings.
 
-The exporter temporality preference is set to "stateless" by default,
-which is not specified presently in OpenTelemetry.  The OpenTelemetry
-specified "delta" temporality preference is not recommended for
-Lightstep users.
+The 1.x launcher release series configures the "cumulative"
+temporality preference by default.  The next major release of launcher
+will configure the "stateless" temporality preference.
+
+Lightstep users are recommended to select either the "cumulative" or
+"stateless" preference.  The OpenTelemetry-specified "delta"
+temporality preference is not recommended for Lightstep users.
 
 ### Metrics validation errors
 

--- a/go.mod
+++ b/go.mod
@@ -59,4 +59,4 @@ replace github.com/lightstep/otel-launcher-go/lightstep/sdk/metric => ./lightste
 // The 1.10.0 release included an unneccessary breaking change of
 // default temporality preference; use 1.10.1 instead or consider
 // upgrading to a 2.x release.
-retract	v1.10.0
+retract v1.10.0

--- a/go.mod
+++ b/go.mod
@@ -55,3 +55,8 @@ require (
 replace github.com/lightstep/otel-launcher-go/pipelines => ./pipelines
 
 replace github.com/lightstep/otel-launcher-go/lightstep/sdk/metric => ./lightstep/sdk/metric
+
+// The 1.10.0 release included an unneccessary breaking change of
+// default temporality preference; use 1.10.1 instead or consider
+// upgrading to a 2.x release.
+retract	v1.10.0

--- a/launcher/config.go
+++ b/launcher/config.go
@@ -212,7 +212,7 @@ type Config struct {
 	Headers                             map[string]string `env:"OTEL_EXPORTER_OTLP_HEADERS"`
 	MetricExporterEndpoint              string            `env:"OTEL_EXPORTER_OTLP_METRIC_ENDPOINT,default=ingest.lightstep.com:443"`
 	MetricExporterEndpointInsecure      bool              `env:"OTEL_EXPORTER_OTLP_METRIC_INSECURE,default=false"`
-	MetricExporterTemporalityPreference string            `env:"OTEL_EXPORTER_OTLP_METRIC_TEMPORALITY_PREFERENCE,default=stateless"`
+	MetricExporterTemporalityPreference string            `env:"OTEL_EXPORTER_OTLP_METRIC_TEMPORALITY_PREFERENCE,default=cumulative"`
 	MetricsEnabled                      bool              `env:"LS_METRICS_ENABLED,default=true"`
 	LogLevel                            string            `env:"OTEL_LOG_LEVEL,default=info"`
 	Propagators                         []string          `env:"OTEL_PROPAGATORS,default=b3"`

--- a/launcher/config_test.go
+++ b/launcher/config_test.go
@@ -375,7 +375,7 @@ func (suite *testSuite) TestDefaultConfig() {
 		MetricExporterEndpointInsecure:      false,
 		MetricReportingPeriod:               "30s",
 		MetricsEnabled:                      true,
-		MetricExporterTemporalityPreference: "stateless",
+		MetricExporterTemporalityPreference: "cumulative",
 		LogLevel:                            "info",
 		Propagators:                         []string{"b3"},
 		Resource:                            resource.NewWithAttributes(semconv.SchemaURL, attributes...),


### PR DESCRIPTION
**Description:** Retract 1.10.0; release 1.10.1 without the change of temporality preference.

**Link to tracking Issue:**
Fixes #260 

**Testing:** Reverts the change in one test.

**Documentation:** Updates the temporality preference docs to be more direct.