### PR TITLE
Add an option to disable builtin metrics LS-33360

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## Unreleased
 
+- Add `WithMetricsBuiltinsEnabled()` option and environment variable
+  `LS_METRICS_BUILTINS_ENABLED`, which defaults to true.  When metrics
+  builtins are enabled,
+  [runtime](https://github.com/open-telemetry/opentelemetry-go-contrib/tree/main/instrumentation/runtime)
+  and
+  [host](https://github.com/open-telemetry/opentelemetry-go-contrib/tree/main/instrumentation/host)
+  metrics instrumentation will be reported automatically.
+
 ## [1.10.1](https://github.com/lightstep/otel-launcher-go/releases/tag/v1.10.1) - 2022-08-29
 
 - Revert the default change of temporality to "cumulative" from #258.

--- a/launcher/config.go
+++ b/launcher/config.go
@@ -214,6 +214,7 @@ type Config struct {
 	MetricExporterEndpointInsecure      bool              `env:"OTEL_EXPORTER_OTLP_METRIC_INSECURE,default=false"`
 	MetricExporterTemporalityPreference string            `env:"OTEL_EXPORTER_OTLP_METRIC_TEMPORALITY_PREFERENCE,default=cumulative"`
 	MetricsEnabled                      bool              `env:"LS_METRICS_ENABLED,default=true"`
+	MetricsBuiltinsEnabled              bool              `env:"LS_METRICS_BUILTINS_ENABLED,default=true"`
 	LogLevel                            string            `env:"OTEL_LOG_LEVEL,default=info"`
 	Propagators                         []string          `env:"OTEL_PROPAGATORS,default=b3"`
 	MetricReportingPeriod               string            `env:"OTEL_EXPORTER_OTLP_METRIC_PERIOD,default=30s"`

--- a/launcher/config.go
+++ b/launcher/config.go
@@ -150,10 +150,18 @@ func WithMetricExporterTemporalityPreference(prefName string) Option {
 	}
 }
 
-// WithMetricEnabled configures whether metrics should be enabled
+// WithMetricEnabled configures whether metrics should be enabled.
 func WithMetricsEnabled(enabled bool) Option {
 	return func(c *Config) {
 		c.MetricsEnabled = enabled
+	}
+}
+
+// WithMetricBuiltinsEnabled configures whether builtin metrics should
+// be enabled.  This has no effect when MetricsEnabled is false.
+func WithMetricsBuiltinsEnabled(builtinsEnabled bool) Option {
+	return func(c *Config) {
+		c.MetricsBuiltinsEnabled = builtinsEnabled
 	}
 }
 
@@ -387,6 +395,7 @@ func setupMetrics(c Config) (func() error, error) {
 		Resource:               c.Resource,
 		ReportingPeriod:        c.MetricReportingPeriod,
 		TemporalityPreference:  c.MetricExporterTemporalityPreference,
+		MetricsBuiltinsEnabled: c.MetricsBuiltinsEnabled,
 		UseLightstepMetricsSDK: c.UseLightstepMetricsSDK,
 	})
 }

--- a/launcher/config_test.go
+++ b/launcher/config_test.go
@@ -375,6 +375,7 @@ func (suite *testSuite) TestDefaultConfig() {
 		MetricExporterEndpointInsecure:      false,
 		MetricReportingPeriod:               "30s",
 		MetricsEnabled:                      true,
+		MetricsBuiltinsEnabled:              true,
 		MetricExporterTemporalityPreference: "cumulative",
 		LogLevel:                            "info",
 		Propagators:                         []string{"b3"},
@@ -676,6 +677,7 @@ func setEnvironment() {
 	os.Setenv("OTEL_RESOURCE_ATTRIBUTES", "service.name=test-service-name-b")
 	os.Setenv("OTEL_EXPORTER_OTLP_METRIC_TEMPORALITY_PREFERENCE", "delta")
 	os.Setenv("LS_METRICS_ENABLED", "false")
+	os.Setenv("LS_METRICS_BUILTINS_ENABLED", "false")
 	os.Setenv("LS_METRICS_SDK", "true")
 }
 
@@ -694,6 +696,7 @@ func unsetEnvironment() {
 		"OTEL_EXPORTER_OTLP_METRIC_PERIOD",
 		"OTEL_EXPORTER_OTLP_METRIC_TEMPORALITY_PREFERENCE",
 		"LS_METRICS_ENABLED",
+		"LS_METRICS_BUILTINS_ENABLED",
 		"LS_METRICS_SDK",
 	}
 	for _, envvar := range vars {

--- a/pipelines/common.go
+++ b/pipelines/common.go
@@ -30,6 +30,10 @@ type PipelineConfig struct {
 	ReportingPeriod string
 	Propagators     []string
 
+	// EnableMetricsBuiltins indicates whether to automatically start
+	// standard host and runtime metrics.
+	EnableMetricsBuiltins bool
+
 	// TemporalityPreference is one of "cumulative", "delta", or "stateless"
 	TemporalityPreference string
 

--- a/pipelines/common.go
+++ b/pipelines/common.go
@@ -30,9 +30,9 @@ type PipelineConfig struct {
 	ReportingPeriod string
 	Propagators     []string
 
-	// EnableMetricsBuiltins indicates whether to automatically start
+	// MetricsBuiltinsEnabled indicates whether to automatically start
 	// standard host and runtime metrics.
-	EnableMetricsBuiltins bool
+	MetricsBuiltinsEnabled bool
 
 	// TemporalityPreference is one of "cumulative", "delta", or "stateless"
 	TemporalityPreference string

--- a/pipelines/metrics.go
+++ b/pipelines/metrics.go
@@ -116,7 +116,7 @@ func NewMetricsPipeline(c PipelineConfig) (func() error, error) {
 		}
 	}
 
-	if c.EnableMetricsBuiltins {
+	if c.MetricsBuiltinsEnabled {
 		if err = runtimeMetrics.Start(runtimeMetrics.WithMeterProvider(provider)); err != nil {
 			return nil, fmt.Errorf("failed to start runtime metrics: %v", err)
 		}

--- a/pipelines/metrics.go
+++ b/pipelines/metrics.go
@@ -116,12 +116,14 @@ func NewMetricsPipeline(c PipelineConfig) (func() error, error) {
 		}
 	}
 
-	if err = runtimeMetrics.Start(runtimeMetrics.WithMeterProvider(provider)); err != nil {
-		return nil, fmt.Errorf("failed to start runtime metrics: %v", err)
-	}
+	if c.EnableMetricsBuiltins {
+		if err = runtimeMetrics.Start(runtimeMetrics.WithMeterProvider(provider)); err != nil {
+			return nil, fmt.Errorf("failed to start runtime metrics: %v", err)
+		}
 
-	if err = hostMetrics.Start(hostMetrics.WithMeterProvider(provider)); err != nil {
-		return nil, fmt.Errorf("failed to start host metrics: %v", err)
+		if err = hostMetrics.Start(hostMetrics.WithMeterProvider(provider)); err != nil {
+			return nil, fmt.Errorf("failed to start host metrics: %v", err)
+		}
 	}
 
 	metricglobal.SetMeterProvider(provider)

--- a/pipelines/metrics_test.go
+++ b/pipelines/metrics_test.go
@@ -48,7 +48,7 @@ func newTLSConfig() *tls.Config {
 	}
 }
 
-func testInsecureMetrics(t *testing.T, lightstepSDK bool) {
+func testInsecureMetrics(t *testing.T, lightstepSDK, builtins bool) {
 	var errors []error
 	otel.SetErrorHandler(otel.ErrorHandlerFunc(func(err error) {
 		errors = append(errors, err)
@@ -68,6 +68,7 @@ func testInsecureMetrics(t *testing.T, lightstepSDK bool) {
 			attribute.String("test-r1", "test-v1"),
 		),
 		ReportingPeriod:        "24h",
+		EnableMetricsBuiltins:  builtins,
 		UseLightstepMetricsSDK: lightstepSDK,
 	})
 	assert.NoError(t, err)
@@ -90,11 +91,17 @@ func testInsecureMetrics(t *testing.T, lightstepSDK bool) {
 
 	require.Equal(t, []string{"test-value"}, server.MetricsMDs()[0]["test-header"])
 
+	if builtins {
+		require.Contains(t, string(txt), "runtime.uptime")
+	} else {
+		require.NotContains(t, string(txt), "runtime.uptime")
+	}
+
 	// There should be no partial errors reported.
 	require.Equal(t, 0, len(errors))
 }
 
-func testSecureMetrics(t *testing.T, lightstepSDK bool) {
+func testSecureMetrics(t *testing.T, lightstepSDK, builtins bool) {
 	server := test.NewServer()
 	defer server.Stop()
 
@@ -109,6 +116,7 @@ func testSecureMetrics(t *testing.T, lightstepSDK bool) {
 		),
 		ReportingPeriod:        "24h",
 		Credentials:            credentials.NewTLS(newTLSConfig()),
+		EnableMetricsBuiltins:  builtins,
 		UseLightstepMetricsSDK: lightstepSDK,
 	})
 	assert.NoError(t, err)
@@ -129,21 +137,43 @@ func testSecureMetrics(t *testing.T, lightstepSDK bool) {
 	require.Contains(t, string(txt), "test-v1")
 	require.Contains(t, string(txt), "test-library")
 
+	if builtins {
+		require.Contains(t, string(txt), "runtime.uptime")
+	} else {
+		require.NotContains(t, string(txt), "runtime.uptime")
+	}
+
 	require.Equal(t, []string{"test-value"}, server.MetricsMDs()[0]["test-header"])
 }
 
 func TestSecureMetricsAltSDK(t *testing.T) {
-	testSecureMetrics(t, true)
+	testSecureMetrics(t, true, true)
 }
 
 func TestSecureMetricsOldSDK(t *testing.T) {
-	testSecureMetrics(t, false)
+	testSecureMetrics(t, false, true)
 }
 
 func TestInsecureMetricsAltSDK(t *testing.T) {
-	testInsecureMetrics(t, true)
+	testInsecureMetrics(t, true, true)
 }
 
 func TestInsecureMetricsOldSDK(t *testing.T) {
-	testInsecureMetrics(t, false)
+	testInsecureMetrics(t, false, true)
+}
+
+func TestSecureMetricsAltSDKNoBuiltins(t *testing.T) {
+	testSecureMetrics(t, true, false)
+}
+
+func TestSecureMetricsOldSDKNoBuiltins(t *testing.T) {
+	testSecureMetrics(t, false, false)
+}
+
+func TestInsecureMetricsAltSDKNoBuiltins(t *testing.T) {
+	testInsecureMetrics(t, true, false)
+}
+
+func TestInsecureMetricsOldSDKNoBuiltins(t *testing.T) {
+	testInsecureMetrics(t, false, false)
 }

--- a/pipelines/metrics_test.go
+++ b/pipelines/metrics_test.go
@@ -68,7 +68,7 @@ func testInsecureMetrics(t *testing.T, lightstepSDK, builtins bool) {
 			attribute.String("test-r1", "test-v1"),
 		),
 		ReportingPeriod:        "24h",
-		EnableMetricsBuiltins:  builtins,
+		MetricsBuiltinsEnabled: builtins,
 		UseLightstepMetricsSDK: lightstepSDK,
 	})
 	assert.NoError(t, err)
@@ -116,7 +116,7 @@ func testSecureMetrics(t *testing.T, lightstepSDK, builtins bool) {
 		),
 		ReportingPeriod:        "24h",
 		Credentials:            credentials.NewTLS(newTLSConfig()),
-		EnableMetricsBuiltins:  builtins,
+		MetricsBuiltinsEnabled: builtins,
 		UseLightstepMetricsSDK: lightstepSDK,
 	})
 	assert.NoError(t, err)


### PR DESCRIPTION
**Description:** Creates a new boolean option `LS_METRICS_BUILTINS_ENABLED` that defaults to true, matching current behavior which is to start the host and runtime metrics.

**Link to tracking Issue:**
Fixes #255. Part of #270.

**Testing:** A new test.

**Documentation:** README updated.