### PR TITLE
Avoid frequent logging of invalid-values (Inf, NaN, Negatives)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   [#265](https://github.com/lightstep/otel-launcher-go/pull/265)
 - Proposed replacement for go-contrib instrumentation/runtime added as lightstep/instrumentation/runtime. 
   [#267](https://github.com/lightstep/otel-launcher-go/pull/267)
+- Avoid repetitive calls to `otel.Handle()` with error conditions caused by 
+  out-of-range metrics input values, includ NaN, Inf, and some negative values.
+  These will be handled no more than once per 30 seconds per condition.
+  [#272](https://github.com/lightstep/otel-launcher-go/pull/272)
 
 ## [1.10.1](https://github.com/lightstep/otel-launcher-go/releases/tag/v1.10.1) - 2022-08-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,9 +18,9 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   [host](https://github.com/open-telemetry/opentelemetry-go-contrib/tree/main/instrumentation/host)
   metrics instrumentation will be reported automatically.
   [#265](https://github.com/lightstep/otel-launcher-go/pull/265)
-- Proposed replacement for go-contrib instrumentation/runtime added as lightstep/instrumentation/runtime. 
+- Proposed replacement for go-contrib instrumentation/runtime added as lightstep/instrumentation/runtime.
   [#267](https://github.com/lightstep/otel-launcher-go/pull/267)
-- Avoid repetitive calls to `otel.Handle()` with error conditions caused by 
+- Avoid repetitive calls to `otel.Handle()` with error conditions caused by
   out-of-range metrics input values, includ NaN, Inf, and some negative values.
   These will be handled no more than once per 30 seconds per condition.
   [#272](https://github.com/lightstep/otel-launcher-go/pull/272)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,9 +20,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   [#265](https://github.com/lightstep/otel-launcher-go/pull/265)
 - Proposed replacement for go-contrib instrumentation/runtime added as lightstep/instrumentation/runtime.
   [#267](https://github.com/lightstep/otel-launcher-go/pull/267)
-- Avoid repetitive calls to `otel.Handle()` with error conditions caused by
-  out-of-range metrics input values, includ NaN, Inf, and some negative values.
-  These will be handled no more than once per 30 seconds per condition.
+- Avoid repetitive calls to `otel.Handle()` with error conditions
+  caused by out-of-range metrics input values, including NaN, Inf, and
+  in some cases negative values.  These will be handled no more than
+  once per 30 seconds per condition.
   [#272](https://github.com/lightstep/otel-launcher-go/pull/272)
 
 ## [1.10.1](https://github.com/lightstep/otel-launcher-go/releases/tag/v1.10.1) - 2022-08-29

--- a/lightstep/sdk/metric/aggregator/aggregator.go
+++ b/lightstep/sdk/metric/aggregator/aggregator.go
@@ -16,9 +16,11 @@ package aggregator // import "github.com/lightstep/otel-launcher-go/lightstep/sd
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/lightstep/otel-launcher-go/lightstep/sdk/metric/aggregator/aggregation"
 	histostruct "github.com/lightstep/otel-launcher-go/lightstep/sdk/metric/aggregator/histogram/structure"
+	"github.com/lightstep/otel-launcher-go/lightstep/sdk/metric/internal/doevery"
 	"github.com/lightstep/otel-launcher-go/lightstep/sdk/metric/number"
 	"github.com/lightstep/otel-launcher-go/lightstep/sdk/metric/sdkinstrument"
 	"go.opentelemetry.io/otel"
@@ -39,12 +41,16 @@ func RangeTest[N number.Any, Traits number.Traits[N]](num N, desc sdkinstrument.
 	var traits Traits
 
 	if traits.IsInf(num) {
-		otel.Handle(fmt.Errorf("%s: %w", desc.Name, ErrInfInput))
+		doevery.TimePeriod(30*time.Second, func() {
+			otel.Handle(fmt.Errorf("%s: %w", desc.Name, ErrInfInput))
+		})
 		return false
 	}
 
 	if traits.IsNaN(num) {
-		otel.Handle(fmt.Errorf("%s: %w", desc.Name, ErrNaNInput))
+		doevery.TimePeriod(30*time.Second, func() {
+			otel.Handle(fmt.Errorf("%s: %w", desc.Name, ErrNaNInput))
+		})
 		return false
 	}
 
@@ -53,7 +59,9 @@ func RangeTest[N number.Any, Traits number.Traits[N]](num N, desc sdkinstrument.
 	case sdkinstrument.SyncCounter,
 		sdkinstrument.SyncHistogram:
 		if num < 0 {
-			otel.Handle(fmt.Errorf("%s: %w", desc.Name, ErrNegativeInput))
+			doevery.TimePeriod(30*time.Second, func() {
+				otel.Handle(fmt.Errorf("%s: %w", desc.Name, ErrNegativeInput))
+			})
 			return false
 		}
 	}

--- a/lightstep/sdk/metric/internal/asyncstate/async_test.go
+++ b/lightstep/sdk/metric/internal/asyncstate/async_test.go
@@ -405,11 +405,18 @@ func TestOutOfRangeValues(t *testing.T) {
 	// one per class.
 	require.LessOrEqual(t, 2, len(*otelErrs))
 
+	haveNaN := false
+	haveInf := false
 	for _, err := range *otelErrs {
 		isNaN := errors.Is(err, aggregator.ErrNaNInput)
 		isInf := errors.Is(err, aggregator.ErrInfInput)
 
 		require.True(t, isNaN || isInf)
 		require.True(t, strings.HasPrefix(err.Error(), "testPattern"))
+
+		haveNaN = haveNaN || isNaN
+		haveInf = haveInf || isInf
 	}
+	require.True(t, haveNaN)
+	require.True(t, haveInf)
 }

--- a/lightstep/sdk/metric/internal/asyncstate/async_test.go
+++ b/lightstep/sdk/metric/internal/asyncstate/async_test.go
@@ -362,13 +362,10 @@ func TestOutOfRangeValues(t *testing.T) {
 	}, tt, func(ctx context.Context) {
 		c.Observe(ctx, math.NaN())
 		c.Observe(ctx, math.Inf(+1))
-		c.Observe(ctx, math.Inf(-1))
 		u.Observe(ctx, math.NaN())
 		u.Observe(ctx, math.Inf(+1))
-		u.Observe(ctx, math.Inf(-1))
 		g.Observe(ctx, math.NaN())
 		g.Observe(ctx, math.Inf(+1))
-		g.Observe(ctx, math.Inf(-1))
 	})
 
 	runFor := func(num int) {
@@ -403,15 +400,16 @@ func TestOutOfRangeValues(t *testing.T) {
 		)
 	}
 
-	// 2 readers x 3 error conditions x 3 instruments
-	require.Equal(t, 2*3*3, len(*otelErrs))
+	// Errors are rate limited, but this is the only test in this
+	// package that uses invalid values.  We should have at least
+	// one per class.
+	require.LessOrEqual(t, 2, len(*otelErrs))
 
 	for _, err := range *otelErrs {
 		isNaN := errors.Is(err, aggregator.ErrNaNInput)
 		isInf := errors.Is(err, aggregator.ErrInfInput)
-		isNeg := errors.Is(err, aggregator.ErrNegativeInput)
 
-		require.True(t, isNaN || isInf || isNeg)
+		require.True(t, isNaN || isInf)
 		require.True(t, strings.HasPrefix(err.Error(), "testPattern"))
 	}
 }


### PR DESCRIPTION
**Description:** These three error conditions, when they occur, are likely to be frequent. By using `doevery`, we avoid repetitive logging of these conditions.

**Link to tracking Issue:** 
Fixes #271.

**Testing:** Modify existing tests.
