### PR TITLE
Optimize and benchmark handling of invalid keys

### DIFF
--- a/lightstep/sdk/metric/benchmark_test.go
+++ b/lightstep/sdk/metric/benchmark_test.go
@@ -19,8 +19,24 @@ import (
 	"testing"
 
 	"github.com/lightstep/otel-launcher-go/lightstep/sdk/metric/data"
+	"github.com/lightstep/otel-launcher-go/lightstep/sdk/metric/view"
 	"go.opentelemetry.io/otel/attribute"
 )
+
+// Tested prior to 0.11.0 release
+// goos: darwin
+// goarch: arm64
+// pkg: github.com/lightstep/otel-launcher-go/lightstep/sdk/metric
+// BenchmarkCounterAddNoAttrs-10                 	35354023	        33.79 ns/op	       0 B/op	       0 allocs/op
+// BenchmarkCounterAddOneAttr-10                 	14354538	        82.77 ns/op	      64 B/op	       1 allocs/op
+// BenchmarkCounterAddOneInvalidAttr-10          	 9307794	       128.4 ns/op	     128 B/op	       1 allocs/op
+// BenchmarkCounterAddManyAttrs-10               	 1000000	      1075 ns/op	     569 B/op	       6 allocs/op
+// BenchmarkCounterAddManyInvalidAttrs-10        	  832549	      1654 ns/op	    1080 B/op	      10 allocs/op
+// BenchmarkCounterAddManyFilteredAttrs-10       	 1000000	      1304 ns/op	     953 B/op	       8 allocs/op
+// BenchmarkCounterCollectOneAttrNoReuse-10      	 2537348	       468.0 ns/op	     400 B/op	       7 allocs/op
+// BenchmarkCounterCollectOneAttrWithReuse-10    	 3679694	       328.2 ns/op	     136 B/op	       3 allocs/op
+// BenchmarkCounterCollectTenAttrs-10            	  715490	      1635 ns/op	     712 B/op	      12 allocs/op
+// BenchmarkCounterCollectTenAttrsTenTimes-10    	   72478	     16475 ns/op	    7128 B/op	     120 allocs/op
 
 func BenchmarkCounterAddNoAttrs(b *testing.B) {
 	ctx := context.Background()
@@ -35,10 +51,6 @@ func BenchmarkCounterAddNoAttrs(b *testing.B) {
 	}
 }
 
-// Benchmark prints 3 allocs per Add():
-//  1. new []attribute.KeyValue for the list of attributes
-//  2. interface{} wrapper around attribute.Set
-//  3. an attribute array (map key)
 func BenchmarkCounterAddOneAttr(b *testing.B) {
 	ctx := context.Background()
 	rdr := NewManualReader("bench")
@@ -52,17 +64,19 @@ func BenchmarkCounterAddOneAttr(b *testing.B) {
 	}
 }
 
-// Benchmark prints 11 allocs per Add(), I see 10 in the profile:
-//  1. new []attribute.KeyValue for the list of attributes
-//  2. an attribute.Sortable (acquireRecord)
-//  3. the attribute.Set underlying array
-//  4. interface{} wrapper around attribute.Set value
-//  5. internal to sync.Map
-//  6. internal sync.Map
-//  7. new syncstate.record
-//  8. new viewstate.syncAccumulator
-//  9. an attribute.Sortable (findOutput)
-// 10. an output Aggregator
+func BenchmarkCounterAddOneInvalidAttr(b *testing.B) {
+	ctx := context.Background()
+	rdr := NewManualReader("bench")
+	provider := NewMeterProvider(WithReader(rdr))
+	b.ReportAllocs()
+
+	cntr, _ := provider.Meter("test").SyncInt64().Counter("hello")
+
+	for i := 0; i < b.N; i++ {
+		cntr.Add(ctx, 1, attribute.String("", "V"), attribute.String("K", "V"))
+	}
+}
+
 func BenchmarkCounterAddManyAttrs(b *testing.B) {
 	ctx := context.Background()
 	rdr := NewManualReader("bench")
@@ -73,6 +87,36 @@ func BenchmarkCounterAddManyAttrs(b *testing.B) {
 
 	for i := 0; i < b.N; i++ {
 		cntr.Add(ctx, 1, attribute.Int("K", i))
+	}
+}
+
+func BenchmarkCounterAddManyInvalidAttrs(b *testing.B) {
+	ctx := context.Background()
+	rdr := NewManualReader("bench")
+	provider := NewMeterProvider(WithReader(rdr))
+	b.ReportAllocs()
+
+	cntr, _ := provider.Meter("test").SyncInt64().Counter("hello")
+
+	for i := 0; i < b.N; i++ {
+		cntr.Add(ctx, 1, attribute.Int("", i), attribute.Int("K", i))
+	}
+}
+
+func BenchmarkCounterAddManyFilteredAttrs(b *testing.B) {
+	ctx := context.Background()
+	rdr := NewManualReader("bench")
+	provider := NewMeterProvider(
+		WithReader(rdr,
+			view.WithClause(view.WithKeys([]attribute.Key{"K"})),
+		),
+	)
+	b.ReportAllocs()
+
+	cntr, _ := provider.Meter("test").SyncInt64().Counter("hello")
+
+	for i := 0; i < b.N; i++ {
+		cntr.Add(ctx, 1, attribute.Int("L", i), attribute.Int("K", i))
 	}
 }
 

--- a/lightstep/sdk/metric/internal/viewstate/base_instrument.go
+++ b/lightstep/sdk/metric/internal/viewstate/base_instrument.go
@@ -96,22 +96,40 @@ func (metric *instrumentBase[N, Storage, Auxiliary, Methods]) mergeDescription(d
 	}
 }
 
-func attributeFilter(viewf *attribute.Filter) attribute.Filter {
-	return func(kv attribute.KeyValue) bool {
-		if kv.Key == "" {
-			doevery.TimePeriod(time.Minute, func() {
-				otel.Handle(fmt.Errorf("use of empty attribute key, e.g., with value %q", kv.Value.Emit()))
-			})
-			return false
-		}
+// isValidAttribute supports filtering invalid attributes.  Note, this
+// should be fast, trye not to allocate!  TODO: match the
+// specification.
+func isValidAttribute(kv attribute.KeyValue) bool {
+	return kv.Key != ""
+}
 
-		return viewf == nil || (*viewf)(kv)
-	}
+func (metric *instrumentBase[N, Storage, Auxiliary, Methods]) invalidAttributeFilter(kv attribute.KeyValue) bool {
+	return isValidAttribute(kv) && (metric.keysFilter == nil || (*metric.keysFilter)(kv))
 }
 
 func (metric *instrumentBase[N, Storage, Auxiliary, Methods]) applyKeysFilter(kvs attribute.Set) attribute.Set {
-	kvs, _ = attribute.NewSetWithFiltered(kvs.ToSlice(), attributeFilter(metric.keysFilter))
-	return kvs
+	invalidFilter := false
+	for iter := kvs.Iter(); iter.Next(); {
+		kv := iter.Attribute()
+		if !isValidAttribute(kv) {
+			doevery.TimePeriod(time.Minute, func() {
+				otel.Handle(fmt.Errorf("use of empty attribute key, e.g., with value %q", kv.Value.Emit()))
+			})
+			invalidFilter = true
+			break
+		}
+	}
+
+	if !invalidFilter && metric.keysFilter == nil {
+		return kvs
+	}
+	var res attribute.Set
+	if !invalidFilter {
+		res, _ = kvs.Filter(*metric.keysFilter)
+	} else {
+		res, _ = kvs.Filter(metric.invalidAttributeFilter)
+	}
+	return res
 }
 
 func (metric *instrumentBase[N, Storage, Auxiliary, Methods]) getOrCreateEntry(kvs attribute.Set) *storageHolder[Storage, Auxiliary] {

--- a/lightstep/sdk/metric/internal/viewstate/base_instrument.go
+++ b/lightstep/sdk/metric/internal/viewstate/base_instrument.go
@@ -97,8 +97,10 @@ func (metric *instrumentBase[N, Storage, Auxiliary, Methods]) mergeDescription(d
 }
 
 // isValidAttribute supports filtering invalid attributes.  Note, this
-// should be fast, trye not to allocate!  TODO: match the
-// specification.
+// should be fast, trye not to allocate!  Note: the specification is
+// somewhat ambiguous about empty strings, see
+// https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/common/attribute-naming.md
+// which just says "valid Unicode sequence".
 func isValidAttribute(kv attribute.KeyValue) bool {
 	return kv.Key != ""
 }

--- a/lightstep/sdk/metric/internal/viewstate/viewstate_test.go
+++ b/lightstep/sdk/metric/internal/viewstate/viewstate_test.go
@@ -1703,11 +1703,11 @@ func TestEmptyKeyFilter(t *testing.T) {
 	inst, err := testCompile(vc, "foo", sdkinstrument.SyncCounter, number.Float64Kind)
 	require.NoError(t, err)
 
-	acc1 := inst.NewAccumulator(attribute.NewSet(attribute.String("", "1value")))
+	acc1 := inst.NewAccumulator(attribute.NewSet(attribute.String("", "1value"), attribute.String("K", "V")))
 	acc1.(Updater[float64]).Update(1)
 	acc1.SnapshotAndProcess(false)
 
-	acc2 := inst.NewAccumulator(attribute.NewSet(attribute.String("", "2value")))
+	acc2 := inst.NewAccumulator(attribute.NewSet(attribute.String("", "2value"), attribute.String("K", "V")))
 	acc2.(Updater[float64]).Update(1)
 	acc2.SnapshotAndProcess(false)
 
@@ -1718,6 +1718,7 @@ func TestEmptyKeyFilter(t *testing.T) {
 			test.Descriptor("foo", sdkinstrument.SyncCounter, number.Float64Kind),
 			test.Point(
 				startTime, endTime, sum.NewMonotonicFloat64(2), cumulative,
+				attribute.String("K", "V"),
 			),
 		),
 	)
@@ -1739,7 +1740,7 @@ func TestEmptyKeyFilterAndView(t *testing.T) {
 	inst, err := testCompile(vc, "foo", sdkinstrument.SyncCounter, number.Float64Kind)
 	require.NoError(t, err)
 
-	acc1 := inst.NewAccumulator(attribute.NewSet(attribute.String("a", "1"), attribute.String("", "empty")))
+	acc1 := inst.NewAccumulator(attribute.NewSet(attribute.String("a", "1"), attribute.String("", "empty"), attribute.String("b", "ignored")))
 	acc1.(Updater[float64]).Update(1)
 	acc1.SnapshotAndProcess(false)
 


### PR DESCRIPTION
**Description:** Observed benchmarks had slipped when introducing handling of invalid keys in  #264 

**Link to tracking Issue:** n/a

**Testing:** New benchmarks added; unittests refined to be sure they cover all cases.

**Documentation:** n/a

BEFORE
```
goos: darwin
goarch: arm64
pkg: github.com/lightstep/otel-launcher-go/lightstep/sdk/metric
BenchmarkCounterAddNoAttrs-10                 	35070174	        34.01 ns/op	       0 B/op	       0 allocs/op
BenchmarkCounterAddOneAttr-10                 	14169888	        83.75 ns/op	      64 B/op	       1 allocs/op
BenchmarkCounterAddOneInvalidAttr-10          	 9203388	       129.6 ns/op	     128 B/op	       1 allocs/op
BenchmarkCounterAddManyAttrs-10               	 1000000	      1162 ns/op	     737 B/op	      10 allocs/op
BenchmarkCounterAddManyInvalidAttrs-10        	  877088	      1616 ns/op	    1230 B/op	      12 allocs/op
BenchmarkCounterAddManyFilteredAttrs-10       	 1000000	      1333 ns/op	     993 B/op	      10 allocs/op
BenchmarkCounterCollectOneAttrNoReuse-10      	 2551692	       468.2 ns/op	     400 B/op	       7 allocs/op
BenchmarkCounterCollectOneAttrWithReuse-10    	 3625554	       329.7 ns/op	     136 B/op	       3 allocs/op
BenchmarkCounterCollectTenAttrs-10            	  711798	      1639 ns/op	     712 B/op	      12 allocs/op
BenchmarkCounterCollectTenAttrsTenTimes-10    	   72469	     16401 ns/op	    7128 B/op	     120 allocs/op

```

AFTER
```
goos: darwin
goarch: arm64
pkg: github.com/lightstep/otel-launcher-go/lightstep/sdk/metric
BenchmarkCounterAddNoAttrs-10                 	34416027	        34.87 ns/op	       0 B/op	       0 allocs/op
BenchmarkCounterAddOneAttr-10                 	14471146	        82.80 ns/op	      64 B/op	       1 allocs/op
BenchmarkCounterAddOneInvalidAttr-10          	 9282039	       128.7 ns/op	     128 B/op	       1 allocs/op
BenchmarkCounterAddManyAttrs-10               	 1000000	      1033 ns/op	     569 B/op	       6 allocs/op
BenchmarkCounterAddManyInvalidAttrs-10        	  803008	      1680 ns/op	    1084 B/op	      10 allocs/op
BenchmarkCounterAddManyFilteredAttrs-10       	 1000000	      1346 ns/op	     954 B/op	       8 allocs/op
BenchmarkCounterCollectOneAttrNoReuse-10      	 2553843	       472.5 ns/op	     400 B/op	       7 allocs/op
BenchmarkCounterCollectOneAttrWithReuse-10    	 3628261	       328.6 ns/op	     136 B/op	       3 allocs/op
BenchmarkCounterCollectTenAttrs-10            	  720498	      1635 ns/op	     712 B/op	      12 allocs/op
BenchmarkCounterCollectTenAttrsTenTimes-10    	   73394	     16465 ns/op	    7128 B/op	     120 allocs/op
```