### PR TITLE
instrumentation/runtime for 1.19.x

### DIFF
--- a/lightstep/instrumentation/runtime/builtin_119_test.go
+++ b/lightstep/instrumentation/runtime/builtin_119_test.go
@@ -17,7 +17,7 @@
 package runtime
 
 var expectRuntimeMetrics = map[string]int{
-	"cgo-to-c-calls":          1,
+	"cgo.go-to-c-calls":       1,
 	"gc.cycles":               2,
 	"gc.heap.allocs":          1,
 	"gc.heap.allocs.objects":  1,

--- a/lightstep/instrumentation/runtime/builtin_test.go
+++ b/lightstep/instrumentation/runtime/builtin_test.go
@@ -63,7 +63,7 @@ func TestBuiltinRuntimeMetrics(t *testing.T) {
 		if expect[name] > 1 {
 			require.Equal(t, 1, len(rec.Attributes))
 		} else {
-			require.Equal(t, 1, expect[name])
+			require.Equal(t, 1, expect[name], "for %v", rec.InstrumentName)
 			require.Equal(t, []attribute.KeyValue(nil), rec.Attributes)
 		}
 		allNames[name]++


### PR DESCRIPTION
**Description:** Go-1.19.2 has been released. Prior versions of 1.19.x did not compile, so the runtime instrumentation was not tested.

**Link to tracking Issue:** #244 

**Testing:** Existing test now passes.

**Documentation:** Was correct, it was only a broken test.