### PR TITLE
Eliminate the ReadMemStats call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## Unreleased
 
+## [1.12.1](https://github.com/lightstep/otel-launcher-go/releases/tag/v1.12.1) - 2022-01-24)
+
+- Eliminate redundant GC cpu-time metric from lightstep/instrumentation/cputime as
+  it is now included in lightstep/instrumentation/runtime from the builtin 
+  runtime/metrics package.  [#355](https://github.com/lightstep/otel-launcher-go/pull/355)
+
 ## [1.12.0](https://github.com/lightstep/otel-launcher-go/releases/tag/v1.12.0) - 2022-12-21)
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -111,8 +111,8 @@ below:
 | Short name | Metrics produced                                                                          |
 |------------|-------------------------------------------------------------------------------------------|
 | host       | system.cpu.time, system.memory.usage, system.memory.utilization, system.network.io        |
-| cputime    | process.cpu.time, process.uptime, process.runtime.go.gc.cpu.time                          |
-| runtime    | process.runtime.go.* generated from [runtime/metrics](https://pkg.go.dev/runtime/metrics) |
+| cputime    | process.cpu.time, process.uptime                                                          |
+| runtime    | process.runtime.go.* generated from [runtime/metrics](https://pkg.go.dev/runtime/metrics), e.g., process.runtime.go.cpu.time |
 
 The available instrumentation library and versions are listed below:
 

--- a/lightstep/instrumentation/cputime/cputime_other.go
+++ b/lightstep/instrumentation/cputime/cputime_other.go
@@ -51,13 +51,7 @@ func newCputime(c config) (*cputime, error) {
 // of Go-1.19 there is no such runtime metric.  User and system sum to
 // 100% of CPU time; gc is an independent, comparable metric value.
 // These are correlated with uptime.
-func (c *cputime) getProcessTimes(ctx context.Context) (userSeconds, systemSeconds, gcSeconds, uptimeSeconds float64) {
-	// Would really be better if runtime/metrics exposed this,
-	// making an expensive call for a single field that is not
-	// exposed via ReadMemStats().
-	var memStats runtime.MemStats
-	runtime.ReadMemStats(&memStats)
-
+func (c *cputime) getProcessTimes(ctx context.Context) (userSeconds, systemSeconds, uptimeSeconds float64) {
 	gomaxprocs := float64(runtime.GOMAXPROCS(0))
 
 	uptimeSeconds = time.Since(processStartTime).Seconds()

--- a/lightstep/instrumentation/cputime/cputime_unix.go
+++ b/lightstep/instrumentation/cputime/cputime_unix.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"fmt"
 	"math"
-	"runtime"
 	"syscall"
 	"time"
 
@@ -48,17 +47,8 @@ func newCputime(c config) (*cputime, error) {
 // of Go-1.19 there is no such runtime metric.  User and system sum to
 // 100% of CPU time; gc is an independent, comparable metric value.
 // These are correlated with uptime.
-func (_ *cputime) getProcessTimes(ctx context.Context) (userSeconds, systemSeconds, gcSeconds, uptimeSeconds float64) {
-	// Would really be better if runtime/metrics exposed this,
-	// making an expensive call for a single field that is not
-	// exposed via ReadMemStats().
-	var memStats runtime.MemStats
-	runtime.ReadMemStats(&memStats)
-
-	gomaxprocs := float64(runtime.GOMAXPROCS(0))
-
+func (_ *cputime) getProcessTimes(ctx context.Context) (userSeconds, systemSeconds, uptimeSeconds float64) {
 	uptimeSeconds = time.Since(processStartTime).Seconds()
-	gcSeconds = memStats.GCCPUFraction * uptimeSeconds * gomaxprocs
 
 	var ru syscall.Rusage
 	if err := syscall.Getrusage(syscall.RUSAGE_SELF, &ru); err != nil {

--- a/pipelines/metrics_test.go
+++ b/pipelines/metrics_test.go
@@ -218,9 +218,9 @@ func TestBuiltins(t *testing.T) {
 		Expect   string
 	}{
 		// invalid entry, valid entry still starts
-		{[]string{"invalid", "cputime"}, "process.runtime.go.gc.cpu.time"},
-		{[]string{"cputime", "invalid"}, "process.runtime.go.gc.cpu.time"},
-		{[]string{"cputime:stable"}, "process.runtime.go.gc.cpu.time"},
+		{[]string{"invalid", "cputime"}, "process.uptime"},
+		{[]string{"cputime", "invalid"}, "process.uptime"},
+		{[]string{"cputime:stable"}, "process.uptime"},
 
 		// invalid version: no library starts
 		{[]string{"cputime:v2"}, ""},


### PR DESCRIPTION
**Description:**

Go-1.19 did not provide `runtime/metrics` for monitoring GC CPU time. The Go-1.20 runtime/metrics do this, so removing the call to `ReadMemStats` is now possible. This is done "simply" by removing the old GC metric.

This should be released ideally before go-1.20 is released.

Users are expected to update to Go-1.20's process.runtime.go.cpu.time{class=gc,...} from lightstep/instrumentation/runtime. Users running go-1.19 will lose this metric and will be advised to run Go-1.20 if monitoring GC CPU time is desired.

**Link to tracking Issue:** Part of #270 (follow-on).

**Testing:** Tested with `gotip` at 1.21 development branch Jan 24, 2023.

**Documentation:** README updated.