### PR TITLE
replace the syncstate RWMutex with Mutex

### DIFF
--- a/lightstep/sdk/metric/internal/syncstate/sync.go
+++ b/lightstep/sdk/metric/internal/syncstate/sync.go
@@ -54,7 +54,7 @@ type Instrument struct {
 	compiled viewstate.Instrument
 
 	// lock protects current.
-	lock sync.RWMutex
+	lock sync.Mutex
 
 	// current is protected by lock.
 	current map[uint64]*record
@@ -336,8 +336,8 @@ func attributesEqual(a, b []attribute.KeyValue) bool {
 
 // acquireRead acquires the read lock and searches for a `*record`.
 func acquireRead(inst *Instrument, fp uint64, attrs []attribute.KeyValue) *record {
-	inst.lock.RLock()
-	defer inst.lock.RUnlock()
+	inst.lock.Lock()
+	defer inst.lock.Unlock()
 
 	rec := inst.current[fp]
 

--- a/lightstep/sdk/metric/internal/syncstate/sync_test.go
+++ b/lightstep/sdk/metric/internal/syncstate/sync_test.go
@@ -108,11 +108,12 @@ func testSyncStateConcurrency[N number.Any, Traits number.Traits[N]](t *testing.
 	// this code.  The race condition still exists, but the test
 	// no longer covers the call to Gosched() in acquireRecord()
 	// or the return-nil branch in acquireWrite().  This is
-	// because with the RWMutex, the race is much less racey.
+	// because the current code is much less racey or better
+	// tests are needed.
 	const (
-		numReaders  = 2
-		numRoutines = 10
-		numAttrs    = 10
+		numReaders  = 10
+		numRoutines = 50
+		numAttrs    = 30
 		numUpdates  = 1e5
 	)
 

--- a/lightstep/sdk/metric/internal/syncstate/sync_test.go
+++ b/lightstep/sdk/metric/internal/syncstate/sync_test.go
@@ -111,9 +111,9 @@ func testSyncStateConcurrency[N number.Any, Traits number.Traits[N]](t *testing.
 	// because the current code is much less racey or better
 	// tests are needed.
 	const (
-		numReaders  = 10
-		numRoutines = 50
-		numAttrs    = 30
+		numReaders  = 2
+		numRoutines = 10
+		numAttrs    = 10
 		numUpdates  = 1e5
 	)
 


### PR DESCRIPTION
**Description:**  Replace a RWMutex with Mutex. We have observed CPU profiles indicating substantial number of callers are falling through the read-lock lookup, speculatively creating an aggregator, only to remove it because of a race. This appears to be a call site where RWMutex leads to harm.

**Link to tracking Issue:** #377 

**Testing:** Repeated existing concurrent tests w/ race detector.

**Documentation:** Updated a comment.