### PR TITLE
Remove access token length check

### DIFF
--- a/launcher/config.go
+++ b/launcher/config.go
@@ -287,11 +287,6 @@ func validateConfiguration(c Config) error {
 		}
 	}
 
-	// TODO(@tobert) will probably break on some providers but seems fine for my use cases right now
-	if accessTokenLen > 0 && (accessTokenLen != 32 && accessTokenLen != 84 && accessTokenLen != 104 && accessToken(c) != "developer") {
-		return fmt.Errorf("invalid configuration: access token length incorrect. Ensure token is set correctly")
-	}
-
 	return nil
 }
 

--- a/launcher/config_test.go
+++ b/launcher/config_test.go
@@ -35,7 +35,6 @@ import (
 )
 
 const (
-	expectedAccessTokenLengthError  = "invalid configuration: access token length incorrect. Ensure token is set correctly"
 	expectedAccessTokenMissingError = "invalid configuration: access token missing, must be set when reporting to ingest.lightstep.com"
 	expectedTracingDisabledMessage  = "tracing is disabled by configuration: no endpoint set"
 	expectedMetricsDisabledMessage  = "metrics are disabled by configuration: no endpoint set"
@@ -203,34 +202,6 @@ func (suite *testSuite) TestInvalidMetricDefaultAccessToken() {
 		append(suite.insecureTraceEndpointOptions(),
 			WithAccessToken(""),
 			WithMetricExporterEndpoint(DefaultMetricExporterEndpoint),
-		)...,
-	)
-}
-
-func (suite *testSuite) testInvalidAccessToken(opts ...Option) {
-	lsOtel := ConfigureOpentelemetry(
-		append(opts,
-			WithLogger(&suite.testLogger),
-			WithServiceName("test-service"),
-		)...,
-	)
-	defer lsOtel.Shutdown()
-
-	suite.requireLogContains(expectedAccessTokenLengthError)
-}
-
-func (suite *testSuite) TestInvalidTraceAccessTokenLength() {
-	suite.testInvalidAccessToken(
-		append(suite.insecureTraceEndpointOptions(),
-			WithAccessToken("1234"),
-		)...,
-	)
-}
-
-func (suite *testSuite) TestInvalidMetricAccessTokenLength() {
-	suite.testInvalidAccessToken(
-		append(suite.bothInsecureEndpointOptions(),
-			WithAccessToken("1234"),
 		)...,
 	)
 }


### PR DESCRIPTION
**Description:** A recent attempt to integrate this library with lightstep.com requires use of an access token of varying length (encoded as a JWT). Currently this is disallowed by the library due to the strict length requirements on the access token. This PR removes that check.

**Link to tracking Issue:** N/A

**Testing:** Fork tested in an application that makes use of the launcher. It is configured via ``` launcher.ConfigureOpentelemetry(
    launcher.WithServiceName(config.App.Name),
    launcher.WithServiceVersion(config.App.Version),
    launcher.WithMetricsEnabled(false)
)``` and the access token is set via `LS_ACCESS_TOKEN` env var.

**Documentation:** N/A