### PR TITLE
[sdk/trace] support trace exporter that uses a batch processor and otlp exporter

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,8 @@ module github.com/lightstep/otel-launcher-go
 go 1.18
 
 require (
+	github.com/f5/otel-arrow-adapter v0.0.0-20230522233737-dc34685b4828
+	github.com/google/go-cmp v0.5.9
 	github.com/lightstep/otel-launcher-go/lightstep/sdk/metric v1.17.1
 	github.com/lightstep/otel-launcher-go/pipelines v1.17.1
 	github.com/sethvargo/go-envconfig v0.8.3

--- a/go.mod
+++ b/go.mod
@@ -7,10 +7,21 @@ require (
 	github.com/lightstep/otel-launcher-go/pipelines v1.17.1
 	github.com/sethvargo/go-envconfig v0.8.3
 	github.com/stretchr/testify v1.8.3
+	go.opentelemetry.io/collector v0.78.1
+	go.opentelemetry.io/collector/component v0.78.1
+	go.opentelemetry.io/collector/consumer v0.78.1
+	go.opentelemetry.io/collector/exporter v0.78.1
+	go.opentelemetry.io/collector/pdata v1.0.0-rcv0012
+	go.opentelemetry.io/collector/processor/batchprocessor v0.78.1
+	go.opentelemetry.io/collector/receiver v0.78.1
 	go.opentelemetry.io/otel v1.15.1
 	go.opentelemetry.io/otel/metric v0.38.1
 	go.opentelemetry.io/otel/sdk v1.15.1
 	go.opentelemetry.io/otel/trace v1.15.1
+	go.opentelemetry.io/proto/otlp v0.19.0
+	go.uber.org/multierr v1.11.0
+	go.uber.org/zap v1.24.0
+	google.golang.org/protobuf v1.30.0
 )
 
 require (
@@ -23,7 +34,7 @@ require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/dgryski/go-farm v0.0.0-20200201041132-a6ae2369ad13 // indirect
 	github.com/dgryski/go-metro v0.0.0-20180109044635-280f6062b5bc // indirect
-	github.com/f5/otel-arrow-adapter v0.0.0-20230522233737-dc34685b4828 // indirect
+	github.com/felixge/httpsnoop v1.0.3 // indirect
 	github.com/fsnotify/fsnotify v1.6.0 // indirect
 	github.com/fxamacker/cbor/v2 v2.4.0 // indirect
 	github.com/go-logr/logr v1.2.4 // indirect
@@ -54,6 +65,7 @@ require (
 	github.com/pierrec/lz4/v4 v4.1.17 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c // indirect
+	github.com/rs/cors v1.9.0 // indirect
 	github.com/shirou/gopsutil/v3 v3.23.4 // indirect
 	github.com/shoenig/go-m1cpu v0.1.5 // indirect
 	github.com/tklauser/go-sysconf v0.3.11 // indirect
@@ -62,17 +74,11 @@ require (
 	github.com/yusufpapurcu/wmi v1.2.2 // indirect
 	github.com/zeebo/xxh3 v1.0.2 // indirect
 	go.opencensus.io v0.24.0 // indirect
-	go.opentelemetry.io/collector v0.78.1 // indirect
-	go.opentelemetry.io/collector/component v0.78.1 // indirect
 	go.opentelemetry.io/collector/confmap v0.78.1 // indirect
-	go.opentelemetry.io/collector/consumer v0.78.1 // indirect
-	go.opentelemetry.io/collector/exporter v0.78.1 // indirect
 	go.opentelemetry.io/collector/featuregate v1.0.0-rcv0012 // indirect
-	go.opentelemetry.io/collector/pdata v1.0.0-rcv0012 // indirect
-	go.opentelemetry.io/collector/processor/batchprocessor v0.78.1 // indirect
-	go.opentelemetry.io/collector/receiver v0.78.1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.41.1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/host v0.41.1 // indirect
+	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.41.1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/runtime v0.41.1 // indirect
 	go.opentelemetry.io/contrib/propagators/b3 v1.16.1 // indirect
 	go.opentelemetry.io/contrib/propagators/ot v1.16.1 // indirect
@@ -82,10 +88,7 @@ require (
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.15.1 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.14.0 // indirect
 	go.opentelemetry.io/otel/sdk/metric v0.38.1 // indirect
-	go.opentelemetry.io/proto/otlp v0.19.0 // indirect
 	go.uber.org/atomic v1.10.0 // indirect
-	go.uber.org/multierr v1.11.0 // indirect
-	go.uber.org/zap v1.24.0 // indirect
 	golang.org/x/exp v0.0.0-20230321023759-10a507213a29 // indirect
 	golang.org/x/mod v0.9.0 // indirect
 	golang.org/x/net v0.10.0 // indirect
@@ -95,7 +98,6 @@ require (
 	golang.org/x/xerrors v0.0.0-20220609144429-65e65417b02f // indirect
 	google.golang.org/genproto v0.0.0-20230410155749-daa745c078e1 // indirect
 	google.golang.org/grpc v1.55.0 // indirect
-	google.golang.org/protobuf v1.30.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 

--- a/go.sum
+++ b/go.sum
@@ -120,6 +120,7 @@ github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5Kwzbycv
 github.com/fatih/color v1.9.0/go.mod h1:eQcE1qtQxscV5RaZvpXrrb8Drkc3/DdQ+uUYCNjL+zU=
 github.com/fatih/structs v1.1.0/go.mod h1:9NiDSp5zOcgEDl+j00MP/WkGVPOlPRLejGD8Ga6PJ7M=
 github.com/felixge/httpsnoop v1.0.3 h1:s/nj+GCswXYzN5v2DpNMuMQYe+0DDwt5WVCU6CWBdXk=
+github.com/felixge/httpsnoop v1.0.3/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/fogleman/gg v1.2.1-0.20190220221249-0403632d5b90/go.mod h1:R/bRT+9gY/C5z7JzPU0zXsXHKM4/ayA+zqcVNZzPa1k=
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
 github.com/fsnotify/fsnotify v1.6.0 h1:n+5WquG0fcWoWp6xPWfHdbskMCQaFnG6PfBrh1Ky4HY=
@@ -393,6 +394,7 @@ github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6L
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/rogpeppe/go-internal v1.10.0 h1:TMyTOH3F/DB16zRVcYyreMH6GnZZrwQVAoYjRBZyWFQ=
 github.com/rs/cors v1.9.0 h1:l9HGsTsHJcvW14Nk7J9KFz8bzeAWXn3CG6bgt7LsrAE=
+github.com/rs/cors v1.9.0/go.mod h1:XyqrcTp5zjWr1wsJ8PIRZssZ8b/WMcMf71DJnit4EMU=
 github.com/ryanuber/columnize v0.0.0-20160712163229-9b3edd62028f/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=
 github.com/ryanuber/columnize v2.1.0+incompatible/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=
 github.com/ryanuber/go-glob v1.0.0/go.mod h1:807d1WSdnB0XRJzKNil9Om6lcp/3a0v4qIHxIXzX/Yc=
@@ -470,11 +472,13 @@ go.opentelemetry.io/collector/processor/batchprocessor v0.78.1 h1:rrKVGvbnzWls1U
 go.opentelemetry.io/collector/processor/batchprocessor v0.78.1/go.mod h1:6rdnvQXPzo0sIhrUVK4bpZ7EmDdR+bSpTdf7gmChhUU=
 go.opentelemetry.io/collector/receiver v0.78.1 h1:MSgnfyIk2OATOvVLJhTFH29rObN6umCEqbeuGLfdUhw=
 go.opentelemetry.io/collector/receiver v0.78.1/go.mod h1:3uz9mktAkTBFcAkwapirH6InuPUL44Oa6MnoXmQJ2ms=
+go.opentelemetry.io/collector/semconv v0.78.1 h1:YlhokDVTP+gw6yKA0Jc2FcfddhD+a6E5Ixmby5xBWs0=
 go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.41.1 h1:Ei1FUQ5CbSNkl2o/XAiksXSyQNAeJBX3ivqJpJ254Ak=
 go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.41.1/go.mod h1:f7TOPTlEcliCBlOYPuNnZTuND71MVTAoINWIt1SmP/c=
 go.opentelemetry.io/contrib/instrumentation/host v0.41.1 h1:B/s7HG33iwus4cwd8NsPk9H6nLKJpLcLgGV2D9RkfsI=
 go.opentelemetry.io/contrib/instrumentation/host v0.41.1/go.mod h1:OdaD/6LjpX5H0ZCKf9EgR6yKFQihVizQMBRLFGlyTP4=
 go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.41.1 h1:pX+lppB8PArapyhS6nBStyQmkaDUPWdQf0UmEGRCQ54=
+go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.41.1/go.mod h1:2FmkXne0k9nkp27LD/m+uoh8dNlstsiCJ7PLc/S72aI=
 go.opentelemetry.io/contrib/instrumentation/runtime v0.41.1 h1:KXWR7rFIuQLMo/dHu/DTev7qdQdTuGCxTfEUZdLaMfs=
 go.opentelemetry.io/contrib/instrumentation/runtime v0.41.1/go.mod h1:fNv3vYJmbcUl4qVQK9tbAVBQjTAbfDDQa/cFgpOTm50=
 go.opentelemetry.io/contrib/propagators/b3 v1.16.1 h1:Y9Dk1kR93eSHadRTkqnm+QyQVhHthCcvTkoP/Afh7+4=

--- a/lightstep/sdk/trace/exporters/otlp/otelcol/client.go
+++ b/lightstep/sdk/trace/exporters/otlp/otelcol/client.go
@@ -1,0 +1,212 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package otelcol
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/f5/otel-arrow-adapter/collector/gen/exporter/otlpexporter"
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/config/configcompression"
+	"go.opentelemetry.io/collector/config/configgrpc"
+	"go.opentelemetry.io/collector/config/configopaque"
+	"go.opentelemetry.io/collector/config/configtls"
+	"go.opentelemetry.io/collector/exporter"
+	"go.opentelemetry.io/collector/exporter/exporterhelper"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/processor"
+	"go.opentelemetry.io/collector/processor/batchprocessor"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/sdk/trace"
+	"go.uber.org/multierr"
+	"go.uber.org/zap"
+)
+
+type Option func(*Config)
+
+type Config struct {
+	Batcher  batchprocessor.Config
+	Exporter otlpexporter.Config
+}
+
+type client struct {
+	once     sync.Once
+	resource pcommon.Resource
+
+	exporter exporter.Traces
+	batcher  processor.Traces
+	settings exporter.CreateSettings
+}
+
+func (c *client) ExportSpans(ctx context.Context, spans []trace.ReadOnlySpan) error {
+	return c.batcher.ConsumeTraces(ctx, c.d2pd(spans))
+}
+
+func (c *client) Shutdown(ctx context.Context) error {
+	var err error
+	if err1 := c.batcher.Shutdown(ctx); err1 != nil {
+		err = multierr.Append(err, err1)
+	}
+	if err2 := c.exporter.Shutdown(ctx); err2 != nil {
+		err = multierr.Append(err, err2)
+	}
+	return err
+}
+
+func NewDefaultConfig() Config {
+	return Config{
+		Batcher: batchprocessor.Config{
+			Timeout:          0,
+			SendBatchSize:    0,
+			SendBatchMaxSize: 10000,
+		},
+		Exporter: otlpexporter.Config{
+			TimeoutSettings: exporterhelper.TimeoutSettings{
+				Timeout: 10 * time.Second,
+			},
+			RetrySettings: exporterhelper.RetrySettings{
+				Enabled: false,
+			},
+			QueueSettings: exporterhelper.QueueSettings{
+				Enabled: false,
+			},
+			GRPCClientSettings: configgrpc.GRPCClientSettings{
+				Headers:         map[string]configopaque.String{},
+				Compression:     configcompression.Zstd,
+				WriteBufferSize: 512 * 1024,
+				WaitForReady:    true,
+			},
+			Arrow: otlpexporter.ArrowSettings{
+				Disabled:         true,
+				NumStreams:       1,
+				DisableDowngrade: true,
+			},
+		},
+	}
+}
+
+func NewConfig(opts ...Option) Config {
+	cfg := NewDefaultConfig()
+	for _, option := range opts {
+		if option != nil {
+			option(&cfg)
+		}
+	}
+	return cfg
+}
+
+func WithEndpoint(addr string) Option {
+	return func(cfg *Config) {
+		cfg.Exporter.GRPCClientSettings.Endpoint = addr
+	}
+}
+
+func WithHeaders(hdrs map[string]string) Option {
+	return func(cfg *Config) {
+		for key, val := range hdrs {
+			cfg.Exporter.GRPCClientSettings.Headers[key] = configopaque.String(val)
+		}
+	}
+}
+
+func WithCompressor(comp string) Option {
+	return func(cfg *Config) {
+		cfg.Exporter.GRPCClientSettings.Compression = configcompression.CompressionType(comp)
+	}
+}
+
+func WithInsecure() Option {
+	return func(cfg *Config) {
+		cfg.Exporter.GRPCClientSettings.TLSSetting.Insecure = true
+	}
+}
+
+func WithTLSSetting(tlss configtls.TLSClientSetting) Option {
+	return func(cfg *Config) {
+		cfg.Exporter.GRPCClientSettings.TLSSetting = tlss
+	}
+}
+
+func NewExporter(ctx context.Context, cfg Config) (trace.SpanExporter, error) {
+	c := &client{}
+
+	if !cfg.Exporter.Arrow.Disabled {
+		c.settings.ID = component.NewID("otlp/arrow")
+	} else {
+		c.settings.ID = component.NewID("otlp/proto")
+	}
+	logger, err := zap.NewProduction()
+	if err != nil {
+		return nil, err
+	}
+
+	c.settings.TelemetrySettings.Logger = logger
+
+	// Note: this may be too much tracing.
+	c.settings.TelemetrySettings.TracerProvider = otel.GetTracerProvider()
+
+	exp, err := otlpexporter.NewFactory().CreateTracesExporter(ctx, c.settings, &cfg.Exporter)
+	if err != nil {
+		return nil, err
+	}
+
+	bset := processor.CreateSettings{
+		ID:                component.NewID("otlp/batch"),
+		TelemetrySettings: c.settings.TelemetrySettings,
+		BuildInfo:         c.settings.BuildInfo,
+	}
+
+	bat, err := batchprocessor.NewFactory().CreateTracesProcessor(ctx, bset, &cfg.Batcher, exp)
+	if err != nil {
+		return nil, err
+	}
+
+	c.exporter = exp
+	c.batcher = bat
+
+	err = exp.Start(ctx, c)
+	if err != nil {
+		return nil, err
+	}
+
+	err = bat.Start(ctx, c)
+	if err != nil {
+		return nil, err
+	}
+
+	return c, nil
+}
+
+// ReportFatalError implements component.Host.
+func (c *client) ReportFatalError(err error) {
+	c.settings.Logger.Fatal("exporter fatal", zap.Error(err))
+}
+
+// GetFactory implements component.Host.
+func (c *client) GetFactory(component.Kind, component.Type) component.Factory {
+	return nil
+}
+
+// GetExtensions implements component.Host.
+func (c *client) GetExtensions() map[component.ID]component.Component {
+	return nil
+}
+
+// GetExporters implements component.Host.
+func (c *client) GetExporters() map[component.DataType]map[component.ID]component.Component {
+	return nil
+}

--- a/lightstep/sdk/trace/exporters/otlp/otelcol/client_test.go
+++ b/lightstep/sdk/trace/exporters/otlp/otelcol/client_test.go
@@ -17,7 +17,6 @@ package otelcol
 import (
 	"context"
 	"encoding/hex"
-	"fmt"
 	"net"
 	"strconv"
 	"testing"

--- a/lightstep/sdk/trace/exporters/otlp/otelcol/client_test.go
+++ b/lightstep/sdk/trace/exporters/otlp/otelcol/client_test.go
@@ -306,8 +306,8 @@ func (t *clientTestSuite) TestD2PD() {
 		t.Equal(attr.Value.AsString(), actualVal.AsString())
 	}
 
-	for _, event := range roSpan.Events() {
-		actualEvent := actualSpan.Events().At(0)
+	for i, event := range roSpan.Events() {
+		actualEvent := actualSpan.Events().At(i)
 		t.Equal(event.Time.Nanosecond(), actualEvent.Timestamp().AsTime().Nanosecond())
 		t.Equal(event.Name, actualEvent.Name())
 		t.Equal(uint32(event.DroppedAttributeCount), actualEvent.DroppedAttributesCount())
@@ -316,6 +316,20 @@ func (t *clientTestSuite) TestD2PD() {
 			actualEventVal, ok := actualEvent.Attributes().Get(string(attr.Key))
 			t.True(ok)
 			t.Equal(attr.Value.AsString(), actualEventVal.AsString())
+		}
+	}
+
+	for i, link := range roSpan.Links() {
+		actualLink := actualSpan.Links().At(i)
+		t.Equal(link.DroppedAttributeCount, actualLink.DroppedAttributesCount())
+		t.Equal(link.SpanContext.SpanID(), actualLink.SpanID())
+		t.Equal(link.SpanContext.TraceID(), actualLink.TraceID())
+		t.Equal(link.SpanContext.TraceState().String(), actualLink.TraceState().AsRaw())
+
+		for _, attr := range link.Attributes {
+			actualLinkVal, ok := actualLink.Attributes().Get(string(attr.Key))
+			t.True(ok)
+			t.Equal(attr.Value.AsString(), actualLinkVal.AsString())
 		}
 	}
 }

--- a/lightstep/sdk/trace/exporters/otlp/otelcol/client_test.go
+++ b/lightstep/sdk/trace/exporters/otlp/otelcol/client_test.go
@@ -58,7 +58,7 @@ type clientTestSuite struct {
 	suite.Suite
 
 	addr   string
-	recv   receiver.Metrics
+	recv   receiver.Traces
 	sink   *consumertest.TracesSink
 	sdk    *sdktrace.TracerProvider
 	before time.Time

--- a/lightstep/sdk/trace/exporters/otlp/otelcol/client_test.go
+++ b/lightstep/sdk/trace/exporters/otlp/otelcol/client_test.go
@@ -128,7 +128,7 @@ func (t *clientTestSuite) SetupSuite() {
 	t.sink = tc
 }
 
-func (t *clientTestSuite) checkTimedPoint(p timedPoint) {
+func (t *clientTestSuite) checkSpanTimestamps(p timedPoint) {
 	if p.StartTimestamp() != 0 {
 		t.LessOrEqual(t.before, p.StartTimestamp().AsTime())
 	}
@@ -154,7 +154,7 @@ func (t *clientTestSuite) assertTimestamps() {
 				ss := rs.ScopeSpans().At(si)
 				for mi := 0; mi < ss.Spans().Len(); mi++ {
 					s := ss.Spans().At(mi)
-					t.checkTimedPoint(s)
+					t.checkSpanTimestamps(s)
 				}
 			}
 		}

--- a/lightstep/sdk/trace/exporters/otlp/otelcol/client_test.go
+++ b/lightstep/sdk/trace/exporters/otlp/otelcol/client_test.go
@@ -29,6 +29,7 @@ import (
 	"go.opentelemetry.io/collector/config/confignet"
 	"go.opentelemetry.io/collector/consumer/consumertest"
 	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/ptrace"
 	"go.opentelemetry.io/collector/pdata/ptrace/ptraceotlp"
 	"go.opentelemetry.io/collector/receiver"
 	"go.opentelemetry.io/collector/receiver/receivertest"
@@ -299,6 +300,9 @@ func (t *clientTestSuite) TestD2PD() {
 	t.Equal(uint32(roSpan.DroppedLinks()), actualSpan.DroppedLinksCount())
 	t.Equal(uint32(roSpan.DroppedEvents()), actualSpan.DroppedEventsCount())
 	t.Equal(uint32(roSpan.SpanKind()), uint32(actualSpan.Kind()))
+	t.Equal(roSpan.SpanContext().TraceState().String(), actualSpan.TraceState().AsRaw())
+	t.Equal(ptrace.StatusCode(roSpan.Status().Code), actualSpan.Status().Code())
+	t.Equal(roSpan.Status().Description, actualSpan.Status().Message())
 
 	for _, attr := range roSpan.Attributes() {
 		actualVal, ok := actualSpan.Attributes().Get(string(attr.Key))

--- a/lightstep/sdk/trace/exporters/otlp/otelcol/client_test.go
+++ b/lightstep/sdk/trace/exporters/otlp/otelcol/client_test.go
@@ -166,10 +166,6 @@ func timeNow() time.Time {
 	return time.Now()
 }
 
-func newFloat64(x float64) *float64 {
-	return &x
-}
-
 func (t *clientTestSuite) TestSpan() {
 	ctx := context.Background()
 

--- a/lightstep/sdk/trace/exporters/otlp/otelcol/client_test.go
+++ b/lightstep/sdk/trace/exporters/otlp/otelcol/client_test.go
@@ -281,7 +281,13 @@ func (t *clientTestSuite) TestD2PD() {
 	tracer := t.sdk.Tracer("test-tracer")
 	_, span := tracer.Start(ctx, "ExecuteRequest")
 	span.SetAttributes(attribute.String("test-attribute-1", "test-value-1"))
-	span.AddEvent("test event")
+	span.AddEvent("test event", trace.WithAttributes(attribute.String("test-event-attribute-1", "test-event-value-1")))
+
+	_, childSpan := tracer.Start(ctx, "child")
+	childSpan.SetAttributes(attribute.String("test-attribute-2", "test-value-2"))
+	childSpan.AddEvent("child test event", trace.WithAttributes(attribute.String("test-child-event-attribute-2", "test-child-event-value-2")))
+	childSpan.End()
+
 	span.End()
 
 	_ = t.sdk.Shutdown(ctx)

--- a/lightstep/sdk/trace/exporters/otlp/otelcol/client_test.go
+++ b/lightstep/sdk/trace/exporters/otlp/otelcol/client_test.go
@@ -52,60 +52,7 @@ var (
 		attribute.String("service.name", "tester"),
 		attribute.String("property", "value"),
 	}
-
-	testStmtAttrs = []attribute.KeyValue{
-		attribute.String("A", "1"),
-		attribute.Int("B", 2),
-	}
 )
-
-func attrs2otlp(kvs ...attribute.KeyValue) []*commonpb.KeyValue {
-	var r []*commonpb.KeyValue
-	for _, kv := range kvs {
-		switch kv.Value.Type() {
-		case attribute.BOOL:
-			r = append(r, &commonpb.KeyValue{
-				Key: string(kv.Key),
-				Value: &commonpb.AnyValue{
-					Value: &commonpb.AnyValue_BoolValue{
-						BoolValue: kv.Value.AsBool(),
-					},
-				},
-			})
-		case attribute.INT64:
-			r = append(r, &commonpb.KeyValue{
-				Key: string(kv.Key),
-				Value: &commonpb.AnyValue{
-					Value: &commonpb.AnyValue_IntValue{
-						IntValue: kv.Value.AsInt64(),
-					},
-				},
-			})
-		case attribute.FLOAT64:
-			r = append(r, &commonpb.KeyValue{
-				Key: string(kv.Key),
-				Value: &commonpb.AnyValue{
-					Value: &commonpb.AnyValue_DoubleValue{
-						DoubleValue: kv.Value.AsFloat64(),
-					},
-				},
-			})
-		case attribute.STRING:
-			r = append(r, &commonpb.KeyValue{
-				Key: string(kv.Key),
-				Value: &commonpb.AnyValue{
-					Value: &commonpb.AnyValue_StringValue{
-						StringValue: kv.Value.AsString(),
-					},
-				},
-			})
-		default:
-			// Note: Missing tests here.
-			panic("untested cases")
-		}
-	}
-	return r
-}
 
 type clientTestSuite struct {
 	suite.Suite

--- a/lightstep/sdk/trace/exporters/otlp/otelcol/client_test.go
+++ b/lightstep/sdk/trace/exporters/otlp/otelcol/client_test.go
@@ -1,0 +1,336 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package otelcol
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/f5/otel-arrow-adapter/collector/gen/receiver/otlpreceiver"
+	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/suite"
+	"go.opentelemetry.io/collector/component/componenttest"
+	"go.opentelemetry.io/collector/config/confignet"
+	"go.opentelemetry.io/collector/consumer/consumertest"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/ptrace/ptraceotlp"
+	"go.opentelemetry.io/collector/receiver"
+	"go.opentelemetry.io/collector/receiver/receivertest"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/sdk/resource"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	coltracepb "go.opentelemetry.io/proto/otlp/collector/trace/v1"
+	tracev1 "go.opentelemetry.io/proto/otlp/trace/v1"
+	commonpb "go.opentelemetry.io/proto/otlp/common/v1"
+	resourcev1 "go.opentelemetry.io/proto/otlp/resource/v1"
+	"google.golang.org/protobuf/encoding/prototext"
+	// "google.golang.org/protobuf/proto"
+)
+
+// Note: unclear which test support library we should use until this
+// moves into an otel repo.  Some simple test supports are developed
+// here anyway to defer this question.
+
+var (
+	testResourceAttrs = []attribute.KeyValue{
+		attribute.String("service.name", "tester"),
+		attribute.String("property", "value"),
+	}
+
+	testStmtAttrs = []attribute.KeyValue{
+		attribute.String("A", "1"),
+		attribute.Int("B", 2),
+	}
+)
+
+func attrs2otlp(kvs ...attribute.KeyValue) []*commonpb.KeyValue {
+	var r []*commonpb.KeyValue
+	for _, kv := range kvs {
+		switch kv.Value.Type() {
+		case attribute.BOOL:
+			r = append(r, &commonpb.KeyValue{
+				Key: string(kv.Key),
+				Value: &commonpb.AnyValue{
+					Value: &commonpb.AnyValue_BoolValue{
+						BoolValue: kv.Value.AsBool(),
+					},
+				},
+			})
+		case attribute.INT64:
+			r = append(r, &commonpb.KeyValue{
+				Key: string(kv.Key),
+				Value: &commonpb.AnyValue{
+					Value: &commonpb.AnyValue_IntValue{
+						IntValue: kv.Value.AsInt64(),
+					},
+				},
+			})
+		case attribute.FLOAT64:
+			r = append(r, &commonpb.KeyValue{
+				Key: string(kv.Key),
+				Value: &commonpb.AnyValue{
+					Value: &commonpb.AnyValue_DoubleValue{
+						DoubleValue: kv.Value.AsFloat64(),
+					},
+				},
+			})
+		case attribute.STRING:
+			r = append(r, &commonpb.KeyValue{
+				Key: string(kv.Key),
+				Value: &commonpb.AnyValue{
+					Value: &commonpb.AnyValue_StringValue{
+						StringValue: kv.Value.AsString(),
+					},
+				},
+			})
+		default:
+			// Note: Missing tests here.
+			panic("untested cases")
+		}
+	}
+	return r
+}
+
+type clientTestSuite struct {
+	suite.Suite
+
+	addr   string
+	recv   receiver.Metrics
+	sink   *consumertest.TracesSink
+	sdk    *sdktrace.TracerProvider
+	before time.Time
+	after  time.Time
+}
+
+type timedPoint interface {
+	StartTimestamp() pcommon.Timestamp
+	EndTimestamp() pcommon.Timestamp
+	SetStartTimestamp(pcommon.Timestamp)
+	SetEndTimestamp(pcommon.Timestamp)
+}
+
+func TestExporterSuite(t *testing.T) {
+	suite.Run(t, new(clientTestSuite))
+}
+
+func (t *clientTestSuite) SetupTest() {
+	ctx := context.Background()
+
+	t.sink.Reset()
+	t.before = timeNow()
+
+	exp, err := NewExporter(
+		ctx,
+		NewConfig(
+			WithInsecure(),
+			WithEndpoint(t.addr),
+			WithHeaders(map[string]string{"lightstep-access-token": "${TOKEN}"}),
+		),
+	)
+	t.NoError(err)
+
+	bsp := sdktrace.NewBatchSpanProcessor(exp)
+	t.sdk = sdktrace.NewTracerProvider(
+		sdktrace.WithResource(
+			resource.NewSchemaless(testResourceAttrs...),
+		),
+		sdktrace.WithSpanProcessor(bsp),
+	)
+}
+
+func (t *clientTestSuite) SetupSuite() {
+	ctx := context.Background()
+
+	listener, err := net.Listen("tcp", "127.0.0.1:")
+	t.NoError(err)
+	t.addr = listener.Addr().String()
+
+	t.NoError(listener.Close())
+
+	factory := otlpreceiver.NewFactory()
+	cfg := factory.CreateDefaultConfig().(*otlpreceiver.Config)
+	cfg.Protocols.Arrow = &otlpreceiver.ArrowSettings{}
+	cfg.GRPC.NetAddr = confignet.NetAddr{Endpoint: t.addr, Transport: "tcp"}
+	cfg.HTTP = nil
+
+	set := receivertest.NewNopCreateSettings()
+	tc := &consumertest.TracesSink{}
+
+	mr, err := factory.CreateTracesReceiver(ctx, set, cfg, tc)
+	t.NoError(err)
+
+	err = mr.Start(ctx, componenttest.NewNopHost())
+	t.NoError(err)
+
+	t.recv = mr
+	t.sink = tc
+}
+
+func (t *clientTestSuite) checkTimedPoint(p timedPoint) {
+	if p.StartTimestamp() != 0 {
+		t.LessOrEqual(t.before, p.StartTimestamp().AsTime())
+	}
+
+	t.LessOrEqual(t.before, t.after)
+	t.LessOrEqual(p.EndTimestamp().AsTime(), t.after)
+
+	t.GreaterOrEqual(t.after, p.EndTimestamp().AsTime())
+	t.LessOrEqual(t.before, p.EndTimestamp().AsTime())
+
+	// Set these fields to zero, making them omitted fields in JSON,
+	// which allows cmp.Diff() uses following this call to work.
+	p.SetStartTimestamp(0)
+	p.SetEndTimestamp(0)
+}
+
+func (t *clientTestSuite) assertTimestamps() {
+	t.after = timeNow()
+	for _, export := range t.sink.AllTraces() {
+		for ri := 0; ri < export.ResourceSpans().Len(); ri++ {
+			rs := export.ResourceSpans().At(ri)
+			for si := 0; si < rs.ScopeSpans().Len(); si++ {
+				ss := rs.ScopeSpans().At(si)
+				for mi := 0; mi < ss.Spans().Len(); mi++ {
+					s := ss.Spans().At(mi)
+					t.checkTimedPoint(s)
+				}
+			}
+		}
+	}
+}
+
+func timeNow() time.Time {
+	return time.Now()
+}
+
+func newFloat64(x float64) *float64 {
+	return &x
+}
+
+func (t *clientTestSuite) TestSpan() {
+	ctx := context.Background()
+
+	tracer := t.sdk.Tracer("test-tracer")
+	_, span := tracer.Start(ctx, "ExecuteRequest")
+	span.SetAttributes(attribute.String("test-attribute-1", "test-value-1"))
+	span.AddEvent("test event")
+	span.End()
+
+	_ = t.sdk.Shutdown(ctx)
+
+	t.Equal(1, len(t.sink.AllTraces()))
+
+	t.assertTimestamps()
+
+	data, err := ptraceotlp.NewExportRequestFromTraces(t.sink.AllTraces()[0]).MarshalJSON()
+	t.NoError(err)
+
+	expectedSpanID, err := span.SpanContext().SpanID().MarshalJSON()
+	t.NoError(err)
+	expectedTraceID, err := span.SpanContext().TraceID().MarshalJSON()
+	t.NoError(err)
+	expect := coltracepb.ExportTraceServiceRequest{
+		ResourceSpans: []*tracev1.ResourceSpans{
+			{
+				Resource: &resourcev1.Resource{
+					Attributes: []*commonpb.KeyValue{
+						&commonpb.KeyValue{
+							Key: "property",
+							Value: &commonpb.AnyValue{
+								Value: &commonpb.AnyValue_StringValue{
+									StringValue: "value",
+								}, 
+							},
+						},
+						&commonpb.KeyValue{
+							Key: "service.name",
+							Value: &commonpb.AnyValue{
+								Value: &commonpb.AnyValue_StringValue{
+									StringValue: "tester",
+								}, 
+							},
+						},
+					},
+				},
+				ScopeSpans: []*tracev1.ScopeSpans{
+					&tracev1.ScopeSpans{
+						Scope: &commonpb.InstrumentationScope{
+							Name: "test-tracer",
+						},
+						Spans: []*tracev1.Span{
+							&tracev1.Span{
+								SpanId: expectedSpanID, 
+								TraceId: expectedTraceID, 
+								Kind: tracev1.Span_SPAN_KIND_INTERNAL,
+								Name: "ExecuteRequest",
+							},
+						},
+					},
+				},
+			},
+			{
+				Resource: &resourcev1.Resource{
+					Attributes: []*commonpb.KeyValue{
+						&commonpb.KeyValue{
+							Key: "property",
+							Value: &commonpb.AnyValue{
+								Value: &commonpb.AnyValue_StringValue{
+									StringValue: "value",
+								}, 
+							},
+						},
+						&commonpb.KeyValue{
+							Key: "service.name",
+							Value: &commonpb.AnyValue{
+								Value: &commonpb.AnyValue_StringValue{
+									StringValue: "tester",
+								}, 
+							},
+						},
+					},
+				},
+				ScopeSpans: []*tracev1.ScopeSpans{
+					&tracev1.ScopeSpans{
+						Scope: &commonpb.InstrumentationScope{
+							Name: "test-tracer",
+						},
+						Spans: []*tracev1.Span{
+							&tracev1.Span{
+								SpanId: expectedSpanID, 
+								TraceId: expectedTraceID, 
+								Kind: tracev1.Span_SPAN_KIND_INTERNAL,
+								Name: "ExecuteRequest",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	var export coltracepb.ExportTraceServiceRequest
+	t.NoError(json.Unmarshal(data, &export))
+	fmt.Println("THIS IS THE EXPECTED")
+	fmt.Println(&expect)
+	fmt.Println("THIS IS THE EXPORT")
+	fmt.Println(&export)
+
+
+	t.Empty(cmp.Diff(prototext.Format(&expect), string(data)))
+}

--- a/lightstep/sdk/trace/exporters/otlp/otelcol/otlp.go
+++ b/lightstep/sdk/trace/exporters/otlp/otelcol/otlp.go
@@ -105,9 +105,19 @@ func (c *client) d2pd(in []trace.ReadOnlySpan) ptrace.Traces {
 		s.SetEndTimestamp(pcommon.NewTimestampFromTime(tr.EndTime()))
 		s.SetTraceID(pcommon.TraceID(tr.SpanContext().TraceID()))
 
-
 		for _, attr := range tr.Attributes() {
 			s.Attributes().PutStr(string(attr.Key), attr.Value.AsString())
+		}
+
+		for _, event := range tr.Events() {
+			e1 := s.Events().AppendEmpty()
+			e1.SetDroppedAttributesCount(uint32(event.DroppedAttributeCount))
+			e1.SetName(event.Name)
+			e1.SetTimestamp(pcommon.Timestamp((event.Time.Nanosecond())))
+
+			for _, attr := range event.Attributes {
+				e1.Attributes().PutStr(string(attr.Key), attr.Value.AsString())
+			}
 		}
 	}
 

--- a/lightstep/sdk/trace/exporters/otlp/otelcol/otlp.go
+++ b/lightstep/sdk/trace/exporters/otlp/otelcol/otlp.go
@@ -127,6 +127,9 @@ func (c *client) d2pd(in []trace.ReadOnlySpan) ptrace.Traces {
 		s.SetStartTimestamp(pcommon.NewTimestampFromTime(tr.StartTime()))
 		s.SetEndTimestamp(pcommon.NewTimestampFromTime(tr.EndTime()))
 		s.SetTraceID(pcommon.TraceID(tr.SpanContext().TraceID()))
+		s.TraceState().FromRaw(tr.SpanContext().TraceState().String())
+		s.Status().SetCode(ptrace.StatusCode(tr.Status().Code))
+		s.Status().SetMessage(tr.Status().Description)
 
 		copyAttributes(s.Attributes(), attribute.NewSet(tr.Attributes()...))
 		copyEvents(s.Events(), tr.Events())

--- a/lightstep/sdk/trace/exporters/otlp/otelcol/otlp.go
+++ b/lightstep/sdk/trace/exporters/otlp/otelcol/otlp.go
@@ -21,6 +21,8 @@ import (
 	"go.opentelemetry.io/otel/sdk/trace"
 )
 
+// TODO: this function is repeated in the sdk/metric exporter
+// so consider creating an internal package to share common code.
 func copyAttributes(dest pcommon.Map, src attribute.Set) {
 	for iter := src.Iter(); iter.Next(); {
 		inA := iter.Attribute()

--- a/lightstep/sdk/trace/exporters/otlp/otelcol/otlp.go
+++ b/lightstep/sdk/trace/exporters/otlp/otelcol/otlp.go
@@ -74,6 +74,7 @@ func (c *client) d2pd(in []trace.ReadOnlySpan) ptrace.Traces {
 			)
 		}
 	})
+
 	out := ptrace.NewTraces()
 	rs := out.ResourceSpans().AppendEmpty()
 
@@ -103,6 +104,11 @@ func (c *client) d2pd(in []trace.ReadOnlySpan) ptrace.Traces {
 		s.SetStartTimestamp(pcommon.NewTimestampFromTime(tr.StartTime()))
 		s.SetEndTimestamp(pcommon.NewTimestampFromTime(tr.EndTime()))
 		s.SetTraceID(pcommon.TraceID(tr.SpanContext().TraceID()))
+
+
+		for _, attr := range tr.Attributes() {
+			s.Attributes().PutStr(string(attr.Key), attr.Value.AsString())
+		}
 	}
 
 	return out

--- a/lightstep/sdk/trace/exporters/otlp/otelcol/otlp.go
+++ b/lightstep/sdk/trace/exporters/otlp/otelcol/otlp.go
@@ -1,0 +1,109 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package otelcol
+
+import (
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/ptrace"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/sdk/trace"
+)
+
+func copyAttributes(dest pcommon.Map, src attribute.Set) {
+	for iter := src.Iter(); iter.Next(); {
+		inA := iter.Attribute()
+		key := string(inA.Key)
+		switch inA.Value.Type() {
+		case attribute.BOOL:
+			dest.PutBool(key, inA.Value.AsBool())
+		case attribute.INT64:
+			dest.PutInt(key, inA.Value.AsInt64())
+		case attribute.FLOAT64:
+			dest.PutDouble(key, inA.Value.AsFloat64())
+		case attribute.STRING:
+			dest.PutStr(key, inA.Value.AsString())
+		case attribute.BOOLSLICE:
+			sl := dest.PutEmptySlice(key)
+			sl.EnsureCapacity(len(inA.Value.AsBoolSlice()))
+			for _, v := range inA.Value.AsBoolSlice() {
+				sl.AppendEmpty().SetBool(v)
+			}
+		case attribute.INT64SLICE:
+			sl := dest.PutEmptySlice(key)
+			sl.EnsureCapacity(len(inA.Value.AsInt64Slice()))
+			for _, v := range inA.Value.AsInt64Slice() {
+				sl.AppendEmpty().SetInt(v)
+			}
+		case attribute.FLOAT64SLICE:
+			sl := dest.PutEmptySlice(key)
+			sl.EnsureCapacity(len(inA.Value.AsFloat64Slice()))
+			for _, v := range inA.Value.AsFloat64Slice() {
+				sl.AppendEmpty().SetDouble(v)
+			}
+		case attribute.STRINGSLICE:
+			sl := dest.PutEmptySlice(key)
+			sl.EnsureCapacity(len(inA.Value.AsStringSlice()))
+			for _, v := range inA.Value.AsStringSlice() {
+				sl.AppendEmpty().SetStr(v)
+			}
+		default:
+			panic("unhandled case")
+		}
+	}
+}
+
+func (c *client) d2pd(in []trace.ReadOnlySpan) ptrace.Traces {
+	c.once.Do(func() {
+		c.resource = pcommon.NewResource()
+		for _, tr := range in {
+			copyAttributes(
+				c.resource.Attributes(),
+				attribute.NewSet(tr.Resource().Attributes()...),
+			)
+		}
+	})
+	out := ptrace.NewTraces()
+	rs := out.ResourceSpans().AppendEmpty()
+
+	c.resource.CopyTo(rs.Resource())
+
+	curName := ""
+	var ss ptrace.ScopeSpans
+	for _, tr := range in {
+		// input is list of ReadOnlySpans. Add spans to the same scopespan
+		// until new scope name is encountered.
+		if ssName := tr.InstrumentationScope().Name; ssName != curName {
+			curName = ssName 
+			ss = rs.ScopeSpans().AppendEmpty()
+			ss.SetSchemaUrl(tr.InstrumentationScope().SchemaURL)
+			ss.Scope().SetName(tr.InstrumentationScope().Name)
+			ss.Scope().SetVersion(tr.InstrumentationScope().Version)
+		}
+
+		s := ss.Spans().AppendEmpty()
+		s.SetDroppedAttributesCount(uint32(tr.DroppedAttributes()))
+		s.SetDroppedEventsCount(uint32(tr.DroppedEvents()))
+		s.SetDroppedLinksCount(uint32(tr.DroppedLinks()))
+		s.SetKind(ptrace.SpanKind(tr.SpanKind()))
+		s.SetName(tr.Name())
+		s.SetParentSpanID(pcommon.SpanID(tr.Parent().SpanID()))
+		s.SetSpanID(pcommon.SpanID(tr.SpanContext().SpanID()))
+		s.SetStartTimestamp(pcommon.NewTimestampFromTime(tr.StartTime()))
+		s.SetEndTimestamp(pcommon.NewTimestampFromTime(tr.EndTime()))
+		s.SetTraceID(pcommon.TraceID(tr.SpanContext().TraceID()))
+	}
+
+	return out
+}


### PR DESCRIPTION
**Description:** 
Adding support for collector based exporting (using batch processor and otlp exporter) for otel-go traces


**Testing:**
Successfully sent traces using a trace exporter from this change
