### PR TITLE
Update OTelCol exporter names used by metrics/trace SDKs

### DIFF
--- a/lightstep/sdk/metric/exporters/otlp/otelcol/client.go
+++ b/lightstep/sdk/metric/exporters/otlp/otelcol/client.go
@@ -132,9 +132,9 @@ func NewExporter(ctx context.Context, cfg Config) (metric.PushExporter, error) {
 	c := &client{}
 
 	if !cfg.Exporter.Arrow.Disabled {
-		c.settings.ID = component.NewID("otlp/arrow")
+		c.settings.ID = component.NewID("otel/sdk/arrow")
 	} else {
-		c.settings.ID = component.NewID("otlp/proto")
+		c.settings.ID = component.NewID("otel/sdk/otlp")
 	}
 	logger, err := zap.NewProduction()
 	if err != nil {
@@ -158,7 +158,7 @@ func NewExporter(ctx context.Context, cfg Config) (metric.PushExporter, error) {
 	}
 
 	bset := processor.CreateSettings{
-		ID:                component.NewID("otlp/batch"),
+		ID:                component.NewID("otel/sdk/batch"),
 		TelemetrySettings: c.settings.TelemetrySettings,
 		BuildInfo:         c.settings.BuildInfo,
 	}

--- a/lightstep/sdk/trace/exporters/otlp/otelcol/client.go
+++ b/lightstep/sdk/trace/exporters/otlp/otelcol/client.go
@@ -145,9 +145,9 @@ func NewExporter(ctx context.Context, cfg Config) (trace.SpanExporter, error) {
 	c := &client{}
 
 	if !cfg.Exporter.Arrow.Disabled {
-		c.settings.ID = component.NewID("otlp/arrow")
+		c.settings.ID = component.NewID("otel/sdk/arrow")
 	} else {
-		c.settings.ID = component.NewID("otlp/proto")
+		c.settings.ID = component.NewID("otel/sdk/otlp")
 	}
 	logger, err := zap.NewProduction()
 	if err != nil {
@@ -165,7 +165,7 @@ func NewExporter(ctx context.Context, cfg Config) (trace.SpanExporter, error) {
 	}
 
 	bset := processor.CreateSettings{
-		ID:                component.NewID("otlp/batch"),
+		ID:                component.NewID("otel/sdk/batch"),
 		TelemetrySettings: c.settings.TelemetrySettings,
 		BuildInfo:         c.settings.BuildInfo,
 	}


### PR DESCRIPTION
**Description:** This modifies the telemetry output by the SDKs regarding their export pipelines.

**Link to tracking Issue:** 
Relates to https://github.com/f5/otel-arrow-adapter/issues/119

**Testing:** n/a
