### PR TITLE
Fix the 1.18.2 release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,7 @@ TOOLS_MOD_DIR := ./tools
 # All source code and documents. Used in spell check.
 ALL_DOCS := $(shell find . -name '*.md' -type f | sort)
 # All directories with go.mod files related to opentelemetry library. Used for building, testing and linting.
+ALLINCLUSIVE_MODULES := $(shell find . -type f -name "go.mod" -exec dirname {} \; | sort )
 ALL_GO_MOD_DIRS := $(filter-out $(TOOLS_MOD_DIR), $(shell find . -type f -name 'go.mod' -exec dirname {} \; | sort))
 ALL_MODULES := $(filter-out $(TOOLS_MOD_DIR), $(shell find . -type f -name "go.mod" -exec dirname {} \; | sort | egrep  '^./' ))
 ALL_COVERAGE_MOD_DIRS := $(shell find . -type f -name 'go.mod' -exec dirname {} \; | egrep -v '^./example|^$(TOOLS_MOD_DIR)' | sort)
@@ -41,6 +42,7 @@ GOTEST_WITH_COVERAGE = $(GOTEST) -coverprofile=coverage.txt -covermode=atomic -c
 .PHONY: precommit
 
 TOOLS_DIR := $(abspath ./.tools)
+
 
 $(TOOLS_DIR)/golangci-lint: $(TOOLS_MOD_DIR)/go.mod $(TOOLS_MOD_DIR)/go.sum $(TOOLS_MOD_DIR)/tools.go
 	cd $(TOOLS_MOD_DIR) && \
@@ -162,6 +164,12 @@ ifdef ver
 else
 		@echo 'ver not defined. call make ver=<version eg 1.2.3> version'
 endif
+
+.PHONY: gotidy
+gotidy:
+	@set -e; for dir in $(ALLINCLUSIVE_MODULES); do \
+	  (echo Tidying "$${dir}" && cd $${dir} && go mod tidy ); \
+	done
 
 .PHONY: add-tag
 add-tag:

--- a/go.mod
+++ b/go.mod
@@ -43,7 +43,7 @@ require (
 	github.com/knadh/koanf v1.5.0 // indirect
 	github.com/lightstep/go-expohisto v1.0.0 // indirect
 	github.com/lightstep/otel-launcher-go/lightstep/instrumentation v1.18.2 // indirect
-	github.com/lightstep/otel-launcher-go/lightstep/sdk/internal v0.0.0-00010101000000-000000000000 // indirect
+	github.com/lightstep/otel-launcher-go/lightstep/sdk/internal v1.18.2 // indirect
 	github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 // indirect
 	github.com/minio/asm2plan9s v0.0.0-20200509001527-cdd76441f9d8 // indirect
 	github.com/minio/c2goasm v0.0.0-20190812172519-36a3d3bbc4f3 // indirect

--- a/lightstep/sdk/metric/example/go.mod
+++ b/lightstep/sdk/metric/example/go.mod
@@ -35,7 +35,7 @@ require (
 	github.com/klauspost/cpuid/v2 v2.0.9 // indirect
 	github.com/knadh/koanf v1.5.0 // indirect
 	github.com/lightstep/go-expohisto v1.0.0 // indirect
-	github.com/lightstep/otel-launcher-go/lightstep/sdk/internal v0.0.0-00010101000000-000000000000 // indirect
+	github.com/lightstep/otel-launcher-go/lightstep/sdk/internal v1.18.2 // indirect
 	github.com/minio/asm2plan9s v0.0.0-20200509001527-cdd76441f9d8 // indirect
 	github.com/minio/c2goasm v0.0.0-20190812172519-36a3d3bbc4f3 // indirect
 	github.com/mitchellh/copystructure v1.2.0 // indirect

--- a/lightstep/sdk/metric/go.mod
+++ b/lightstep/sdk/metric/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/golang/mock v1.6.0
 	github.com/google/go-cmp v0.5.9
 	github.com/lightstep/go-expohisto v1.0.0
-	github.com/lightstep/otel-launcher-go/lightstep/sdk/internal v0.0.0-00010101000000-000000000000
+	github.com/lightstep/otel-launcher-go/lightstep/sdk/internal v1.18.2
 	github.com/stretchr/testify v1.8.4
 	go.opentelemetry.io/collector v0.79.0
 	go.opentelemetry.io/collector/component v0.79.0

--- a/lightstep/sdk/trace/go.mod
+++ b/lightstep/sdk/trace/go.mod
@@ -5,7 +5,7 @@ go 1.18
 require (
 	github.com/f5/otel-arrow-adapter v0.0.0-20230612212022-445aac7c6ae8
 	github.com/google/go-cmp v0.5.9
-	github.com/lightstep/otel-launcher-go/lightstep/sdk/internal v0.0.0-00010101000000-000000000000
+	github.com/lightstep/otel-launcher-go/lightstep/sdk/internal v1.18.2
 	github.com/stretchr/testify v1.8.4
 	go.opentelemetry.io/collector v0.79.0
 	go.opentelemetry.io/collector/component v0.79.0

--- a/pipelines/go.mod
+++ b/pipelines/go.mod
@@ -79,7 +79,7 @@ require (
 	github.com/klauspost/cpuid/v2 v2.0.9 // indirect
 	github.com/knadh/koanf v1.5.0 // indirect
 	github.com/lightstep/go-expohisto v1.0.0 // indirect
-	github.com/lightstep/otel-launcher-go/lightstep/sdk/internal v0.0.0-00010101000000-000000000000 // indirect
+	github.com/lightstep/otel-launcher-go/lightstep/sdk/internal v1.18.2 // indirect
 	github.com/minio/asm2plan9s v0.0.0-20200509001527-cdd76441f9d8 // indirect
 	github.com/minio/c2goasm v0.0.0-20190812172519-36a3d3bbc4f3 // indirect
 	github.com/mitchellh/copystructure v1.2.0 // indirect

--- a/tools/tag_version.sh
+++ b/tools/tag_version.sh
@@ -26,6 +26,8 @@ sed -i '' "s/const version.*/const version = \"$VERSION\"/" ./launcher/version.g
 
 (cd pipelines && go get github.com/lightstep/otel-launcher-go/lightstep/sdk/metric@v$VERSION)
 (cd pipelines && go get github.com/lightstep/otel-launcher-go/lightstep/instrumentation@v$VERSION)
+(cd lightstep/sdk/metric && go get github.com/lightstep/otel-launcher-go/lightstep/sdk/internal@v$VERSION)
+(cd lightstep/sdk/trace && go get github.com/lightstep/otel-launcher-go/lightstep/sdk/internal@v$VERSION)
 (cd lightstep/sdk/metric/example && go get github.com/lightstep/otel-launcher-go/lightstep/sdk/metric@v$VERSION)
 
 go get github.com/lightstep/otel-launcher-go/pipelines@v$VERSION


### PR DESCRIPTION
**Description:** The tag_version.sh script needs to be updated when new inter-repo dependencies are introduced.

See #490, which broke the dependencies.
