### PR TITLE
runtime/metrics definitions for go 1.21 runtime

### DIFF
--- a/lightstep/instrumentation/runtime/builtin_test.go
+++ b/lightstep/instrumentation/runtime/builtin_test.go
@@ -387,7 +387,7 @@ func makeTestCaseBuiltin(t *testing.T) (allFunc, readFunc, *builtinDescriptor, t
 
 	for goname, realval := range testMap {
 		mname, munit, descPat, attrs, kind, err := realDesc.findMatch(goname)
-		if err != nil || mname == "" {
+		if err != nil || mname == "" || kind == builtinSkip {
 			continue // e.g., async histogram data, totalized metrics
 		}
 		noprefix := mname[len(namePrefix)+1:]

--- a/lightstep/instrumentation/runtime/defs.go
+++ b/lightstep/instrumentation/runtime/defs.go
@@ -16,9 +16,11 @@ package runtime
 
 func expectRuntimeMetrics() *builtinDescriptor {
 	bd := newBuiltinDescriptor()
+	bd.ignorePattern("/godebug/non-default-behavior/*:events")
 	bd.classesCounter("/cpu/classes/*:cpu-seconds")
 	bd.classesCounter("/gc/cycles/*:gc-cycles")
 	bd.classesUpDownCounter("/memory/classes/*:bytes")
+	bd.classesUpDownCounter("/gc/scan/*:bytes")
 	bd.ignoreHistogram("/gc/heap/allocs-by-size:bytes")
 	bd.ignoreHistogram("/gc/heap/frees-by-size:bytes")
 	bd.ignoreHistogram("/gc/pauses:seconds")
@@ -28,7 +30,10 @@ func expectRuntimeMetrics() *builtinDescriptor {
 	bd.singleCounter("/cgo/go-to-c-calls:calls")
 	bd.singleCounter("/gc/heap/tiny/allocs:objects")
 	bd.singleCounter("/sync/mutex/wait/total:seconds")
+	bd.singleGauge("/gc/gogc:percent")
+	bd.singleGauge("/gc/gomemlimit:bytes")
 	bd.singleGauge("/gc/heap/goal:bytes")
+	bd.singleGauge("/gc/heap/live:bytes")
 	bd.singleGauge("/gc/limiter/last-enabled:gc-cycle")
 	bd.singleGauge("/gc/stack/starting-size:bytes")
 	bd.singleGauge("/sched/gomaxprocs:threads")

--- a/lightstep/instrumentation/runtime/descriptor.go
+++ b/lightstep/instrumentation/runtime/descriptor.go
@@ -118,6 +118,10 @@ func (bd *builtinDescriptor) singleGauge(pattern string) {
 	bd.add(pattern, builtinGauge)
 }
 
+func (bd *builtinDescriptor) ignorePattern(pattern string) {
+	bd.add(pattern, builtinSkip)
+}
+
 func (bd *builtinDescriptor) ignoreHistogram(pattern string) {
 	bd.add(pattern, builtinHistogram)
 }


### PR DESCRIPTION
**Description:** 
Updates for Go 1.21
There are 3 new single gauges, one new class-updowncounter, and a pattern of non-default-behavior counters from /godebug I think we should skip.

Part of https://github.com/lightstep/otel-launcher-go/issues/257
