### PR TITLE
Give distinct names to the trace/metrics batch processors in the otelcol-based exporters

### DIFF
--- a/lightstep/sdk/metric/exporters/otlp/otelcol/client.go
+++ b/lightstep/sdk/metric/exporters/otlp/otelcol/client.go
@@ -169,7 +169,7 @@ func NewExporter(ctx context.Context, cfg Config) (metric.PushExporter, error) {
 	}
 
 	bset := processor.CreateSettings{
-		ID:                component.NewID("otel/sdk/batch"),
+		ID:                component.NewID("otel/sdk/metric/batch"),
 		TelemetrySettings: c.settings.TelemetrySettings,
 		BuildInfo:         c.settings.BuildInfo,
 	}

--- a/lightstep/sdk/trace/exporters/otlp/otelcol/client.go
+++ b/lightstep/sdk/trace/exporters/otlp/otelcol/client.go
@@ -182,7 +182,7 @@ func NewExporter(ctx context.Context, cfg Config) (trace.SpanExporter, error) {
 	}
 
 	bset := processor.CreateSettings{
-		ID:                component.NewID("otel/sdk/batch"),
+		ID:                component.NewID("otel/sdk/trace/batch"),
 		TelemetrySettings: c.settings.TelemetrySettings,
 		BuildInfo:         c.settings.BuildInfo,
 	}


### PR DESCRIPTION
**Description:** The trace and metric SDKs both use the same processor with the same name, which makes a single-writer rule violation. Insert "trace" and "metric" accordingly, following the pattern used for the exporters (which _did_ distinguish the two already).