### PR TITLE
LS Metrics SDK: Implement attribute size limits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## Unreleased
 
+- LS Metrics SDK add an `AttributeSizeLimit` [#588](https://github.com/lightstep/otel-launcher-go/pull/588)
+- Change the name of the otelcol batch processor to indicate whether traces or metrics. [#587](https://github.com/lightstep/otel-launcher-go/pull/587)
+
 ## [1.22.0](https://github.com/lightstep/otel-launcher-go/releases/tag/v1.22.0) - 2023-11-27)
 
 - Use the OTel-Arrow concurrent batch processor in SDK exporters based on the OTel collector. [#569](https://github.com/lightstep/otel-launcher-go/pull/569)

--- a/lightstep/sdk/metric/README.md
+++ b/lightstep/sdk/metric/README.md
@@ -193,3 +193,9 @@ context and/or W3C Tracecontext baggage.
 This hook also supports removing attributes from metric events based
 on attribute value before they are aggregated, for example to
 dynamically configure allowed cardinality values.
+
+#### AttributeSizeLimit
+
+This limit is used to truncate attribute key and string values to a
+reasonable size.  The default limit is 8kB.  Zero is not a valid
+limit.

--- a/lightstep/sdk/metric/internal/syncstate/sync.go
+++ b/lightstep/sdk/metric/internal/syncstate/sync.go
@@ -348,6 +348,8 @@ func Observe[N number.Any, Traits number.Traits[N]](ctx context.Context, inst *O
 		keyValues = cfg.Attributes.ToSlice()
 	}
 
+	keyValues = inst.performance.TruncateAttributes(keyValues)
+
 	if inst.performance.MeasurementProcessor != nil {
 		keyValues = inst.performance.MeasurementProcessor.Process(ctx, keyValues)
 	}

--- a/lightstep/sdk/metric/internal/syncstate/sync_test.go
+++ b/lightstep/sdk/metric/internal/syncstate/sync_test.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"math"
 	"math/rand"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -1449,4 +1450,57 @@ func TestInputAttributeSliceRaceCondition(t *testing.T) {
 	}()
 
 	wg.Wait()
+}
+
+func TestAttributeSizeLimit(t *testing.T) {
+	ctx := context.Background()
+	lib := instrumentation.Library{
+		Name: "testlib",
+	}
+	// This enters a default value
+	perf := sdkinstrument.Performance{}.Validate()
+	perf.AttributeSizeLimit = 100
+	vcs := make([]*viewstate.Compiler, 2)
+	vcs[0] = viewstate.New(lib, view.New(
+		"test",
+		perf,
+		deltaSelector,
+	))
+
+	desc := test.Descriptor(
+		"counter",
+		sdkinstrument.SyncCounter,
+		number.Float64Kind)
+
+	pipes := make(pipeline.Register[viewstate.Instrument], 1)
+	pipes[0], _ = vcs[0].Compile(desc)
+
+	require.NotNil(t, pipes[0])
+
+	inst := New(desc, perf, nil, pipes)
+	require.NotNil(t, inst)
+
+	inst.ObserveFloat64(ctx, 1, attrsConfig(attribute.String(strings.Repeat("X", 1<<20), strings.Repeat("Y", 1<<20))))
+	inst.ObserveFloat64(ctx, 2, attrsConfig(attribute.String(strings.Repeat("X", 1<<20), strings.Repeat("Y", 1<<20))))
+	inst.ObserveFloat64(ctx, 3, attrsConfig(attribute.String(strings.Repeat("X", 1<<20), strings.Repeat("Y", 1<<20))))
+
+	limit := int(perf.AttributeSizeLimit)
+
+	inst.SnapshotAndProcess()
+	test.RequireEqualMetrics(
+		t,
+		test.CollectScope(
+			t,
+			vcs[0].Collectors(),
+			testSequence,
+		),
+		test.Instrument(
+			desc,
+			test.Point(middleTime, endTime,
+				sum.NewMonotonicFloat64(6),
+				aggregation.DeltaTemporality,
+				attribute.String(strings.Repeat("X", limit), strings.Repeat("Y", limit)),
+			),
+		),
+	)
 }

--- a/lightstep/sdk/metric/sdkinstrument/performance_test.go
+++ b/lightstep/sdk/metric/sdkinstrument/performance_test.go
@@ -71,6 +71,21 @@ func TestTruncateAttrs(t *testing.T) {
 				}),
 			),
 		},
+		{
+			Name: "mixed",
+			Attrs: mkAttrs(
+				attribute.Int("int", 1),
+				attribute.Float64("float", 1),
+				attribute.Bool("bool", true),
+				attribute.String("str", strings.Repeat("Y", 1024)),
+			),
+			Expect: mkAttrs(
+				attribute.Int("int", 1),
+				attribute.Float64("float", 1),
+				attribute.Bool("bool", true),
+				attribute.String("str", strings.Repeat("Y", Limit)),
+			),
+		},
 	} {
 		t.Run(test.Name, func(t *testing.T) {
 			perf := Performance{}.Validate()

--- a/lightstep/sdk/metric/sdkinstrument/performance_test.go
+++ b/lightstep/sdk/metric/sdkinstrument/performance_test.go
@@ -1,0 +1,83 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sdkinstrument
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/attribute"
+)
+
+func TestTruncateAttrs(t *testing.T) {
+	const Limit = 16
+
+	type test struct {
+		Name   string
+		Attrs  []attribute.KeyValue
+		Expect []attribute.KeyValue
+	}
+
+	mkAttrs := func(attrs ...attribute.KeyValue) []attribute.KeyValue {
+		return attrs
+	}
+
+	for _, test := range []test{
+		{
+			Name:   "simple",
+			Attrs:  mkAttrs(attribute.String(strings.Repeat("X", 1024), strings.Repeat("Y", 1024))),
+			Expect: mkAttrs(attribute.String(strings.Repeat("X", Limit), strings.Repeat("Y", Limit))),
+		},
+		{
+			Name: "several",
+			Attrs: mkAttrs(
+				attribute.String("small", "unmodified"),
+				attribute.String(strings.Repeat("X", 1024), strings.Repeat("Y", 1024)),
+				attribute.String("small", "unmodified"),
+			),
+			Expect: mkAttrs(
+				attribute.String("small", "unmodified"),
+				attribute.String(strings.Repeat("X", Limit), strings.Repeat("Y", Limit)),
+				attribute.String("small", "unmodified"),
+			),
+		},
+		{
+			Name: "slice",
+			Attrs: mkAttrs(
+				attribute.StringSlice("slice", []string{
+					"simple",
+					strings.Repeat("X", 1024), strings.Repeat("Y", 1024),
+					"extra",
+				}),
+			),
+			Expect: mkAttrs(
+				attribute.StringSlice("slice", []string{
+					"simple",
+					strings.Repeat("X", Limit), strings.Repeat("Y", Limit),
+					"extra",
+				}),
+			),
+		},
+	} {
+		t.Run(test.Name, func(t *testing.T) {
+			perf := Performance{}.Validate()
+			perf.AttributeSizeLimit = Limit
+			require.Equal(t,
+				test.Expect,
+				perf.TruncateAttributes(test.Attrs))
+		})
+	}
+}


### PR DESCRIPTION
**Description:** Adds `sdkinstrument.Performance` field named `AttributeSizeLimit` to limit attribute key and value size. Default is 8kB.

**Link to tracking Issue:** Internal: LS-56746.

**Testing:** New.

**Documentation:** New.