### PR TITLE
exporter: allow custom meter/trace providers

### DIFF
--- a/lightstep/sdk/trace/exporters/otlp/otelcol/client.go
+++ b/lightstep/sdk/trace/exporters/otlp/otelcol/client.go
@@ -57,7 +57,7 @@ type Config struct {
 }
 
 type ExporterOptions struct {
-	TracerProvider *trace.TracerProvider
+	TracerProvider traceapi.TracerProvider
 	MeterProvider  metric.MeterProvider
 }
 

--- a/lightstep/sdk/trace/exporters/otlp/otelcol/client.go
+++ b/lightstep/sdk/trace/exporters/otlp/otelcol/client.go
@@ -61,7 +61,7 @@ type ExporterOptions struct {
 	MeterProvider  metric.MeterProvider
 }
 
-func WithTracerProvider(tp *trace.TracerProvider) func(*ExporterOptions) {
+func WithTracerProvider(tp traceapi.TracerProvider) func(*ExporterOptions) {
 	return func(opts *ExporterOptions) {
 		opts.TracerProvider = tp
 	}


### PR DESCRIPTION
This adds a feature to allow passing in a custom trace and metric provider for the self-reporting features.

To do this, alter `NewExporter` to employ the variadic options pattern over a new options struct, `ExporterOptions`. `Options` is already used by the some `Config` building contraptions.

This does make the package namespace a little crowded... `With*` functions can apply to either the exporter or the config, but I don't know that makes it confusing enough to split things up yet.