### PR TITLE
Use default OTel Collector retry settings (vs zero values)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## Unreleased
 
+- Use correct default retry settings. [#741](https://github.com/lightstep/otel-launcher-go/pull/741)
+
 ## [1.30.0](https://github.com/lightstep/otel-launcher-go/releases/tag/v1.30.0) - 2024-07-17
 
 - Update OpenTelemetry-Arrow components to latest, now in collector-contrib. [#736](https://github.com/lightstep/otel-launcher-go/pull/736)

--- a/lightstep/sdk/metric/exporters/otlp/otelcol/client.go
+++ b/lightstep/sdk/metric/exporters/otlp/otelcol/client.go
@@ -69,7 +69,7 @@ type client struct {
 }
 
 func NewDefaultConfig() Config {
-	return Config{
+	cfg := Config{
 		SelfMetrics: true,
 		SelfSpans:   true,
 		Batcher: concurrentbatchprocessor.Config{
@@ -82,12 +82,8 @@ func NewDefaultConfig() Config {
 			TimeoutSettings: exporterhelper.TimeoutSettings{
 				Timeout: 15 * time.Second,
 			},
-			RetryConfig: configretry.BackOffConfig{
-				Enabled: false,
-			},
-			QueueSettings: exporterhelper.QueueSettings{
-				Enabled: false,
-			},
+			RetryConfig:   configretry.NewDefaultBackOffConfig(),
+			QueueSettings: exporterhelper.NewDefaultQueueSettings(),
 			ClientConfig: configgrpc.ClientConfig{
 				Headers:         map[string]configopaque.String{},
 				Compression:     configcompression.TypeZstd,
@@ -101,6 +97,10 @@ func NewDefaultConfig() Config {
 			},
 		},
 	}
+	// All RetryConfig and QueueSettings are taken from the defaults, but disabled.
+	cfg.Exporter.RetryConfig.Enabled = false
+	cfg.Exporter.QueueSettings.Enabled = false
+	return cfg
 }
 
 func NewConfig(opts ...Option) Config {

--- a/lightstep/sdk/trace/exporters/otlp/otelcol/client.go
+++ b/lightstep/sdk/trace/exporters/otlp/otelcol/client.go
@@ -130,7 +130,7 @@ func (c *client) Shutdown(ctx context.Context) error {
 }
 
 func NewDefaultConfig() Config {
-	return Config{
+	cfg := Config{
 		SelfMetrics: true,
 		SelfSpans:   true,
 		Batcher: concurrentbatchprocessor.Config{
@@ -143,12 +143,8 @@ func NewDefaultConfig() Config {
 			TimeoutSettings: exporterhelper.TimeoutSettings{
 				Timeout: 15 * time.Second,
 			},
-			RetryConfig: configretry.BackOffConfig{
-				Enabled: false,
-			},
-			QueueSettings: exporterhelper.QueueSettings{
-				Enabled: false,
-			},
+			RetryConfig:   configretry.NewDefaultBackOffConfig(),
+			QueueSettings: exporterhelper.NewDefaultQueueSettings(),
 			ClientConfig: configgrpc.ClientConfig{
 				Headers:         map[string]configopaque.String{},
 				Compression:     configcompression.TypeZstd,
@@ -162,6 +158,10 @@ func NewDefaultConfig() Config {
 			},
 		},
 	}
+	// All RetryConfig and QueueSettings are taken from the defaults, but disabled.
+	cfg.Exporter.RetryConfig.Enabled = false
+	cfg.Exporter.QueueSettings.Enabled = false
+	return cfg
 }
 
 func NewConfig(opts ...Option) Config {


### PR DESCRIPTION
**Description:** The default values for RetrySettings are problematic because they have zeros. If a caller should enable the retry settings w/o setting all fields, some of them are zero. We observed that a Multiplier of zero is bad because it causes a tight loop to retry spans.
