### PR TITLE
Add admission control to traces sdk

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,8 @@ require (
 	github.com/HdrHistogram/hdrhistogram-go v1.1.2 // indirect
 	github.com/apache/arrow/go/v16 v16.1.0 // indirect
 	github.com/axiomhq/hyperloglog v0.0.0-20230201085229-3ddf4bad03dc // indirect
+	github.com/bahlo/generic-list-go v0.2.0 // indirect
+	github.com/buger/jsonparser v1.1.1 // indirect
 	github.com/cenkalti/backoff/v4 v4.3.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/dgryski/go-farm v0.0.0-20200201041132-a6ae2369ad13 // indirect
@@ -47,6 +49,7 @@ require (
 	github.com/lightstep/otel-launcher-go/lightstep/sdk/metric v1.30.0 // indirect
 	github.com/lightstep/otel-launcher-go/lightstep/sdk/trace v1.29.0 // indirect
 	github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 // indirect
+	github.com/mailru/easyjson v0.7.7 // indirect
 	github.com/mitchellh/copystructure v1.2.0 // indirect
 	github.com/mitchellh/reflectwalk v1.0.2 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
@@ -63,6 +66,7 @@ require (
 	github.com/shoenig/go-m1cpu v0.1.6 // indirect
 	github.com/tklauser/go-sysconf v0.3.12 // indirect
 	github.com/tklauser/numcpus v0.6.1 // indirect
+	github.com/wk8/go-ordered-map/v2 v2.1.8 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
 	github.com/yusufpapurcu/wmi v1.2.4 // indirect
 	github.com/zeebo/xxh3 v1.0.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -65,6 +65,7 @@ github.com/grpc-ecosystem/grpc-gateway/v2 v2.20.0 h1:bkypFPDjIYGfCYD5mRBvpqxfYX1
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.20.0/go.mod h1:P+Lt/0by1T8bfcF3z737NnSbmxQAppXMRziHUxPOC8k=
 github.com/hashicorp/go-version v1.7.0 h1:5tqGy27NaOTB8yJKUZELlFAS/LTKJkrmONwQKeRZfjY=
 github.com/hashicorp/go-version v1.7.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
+github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
 github.com/jung-kurt/gofpdf v1.0.3-0.20190309125859-24315acbbda5/go.mod h1:7Id9E/uU8ce6rXgefFLlgrJj/GYY22cpxn+r32jIOes=

--- a/lightstep/sdk/trace/exporters/otlp/otelcol/client.go
+++ b/lightstep/sdk/trace/exporters/otlp/otelcol/client.go
@@ -17,12 +17,11 @@ package otelcol
 import (
 	"context"
 	"errors"
-	"fmt"
 	"time"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/otelarrowexporter"
-	"github.com/open-telemetry/otel-arrow/collector/processor/concurrentbatchprocessor"
 	"github.com/open-telemetry/otel-arrow/collector/admission"
+	"github.com/open-telemetry/otel-arrow/collector/processor/concurrentbatchprocessor"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config/configcompression"
 	"go.opentelemetry.io/collector/config/configgrpc"
@@ -123,8 +122,6 @@ func (c *client) ExportSpans(ctx context.Context, spans []trace.ReadOnlySpan) (r
 	for _, span := range spans {
 		spanSz += sizeOfROSpan(span)
 	}
-	fmt.Println("SPAN SIZE")
-	fmt.Println(spanSz)
 	retErr = c.boundedQueue.Acquire(ctx, int64(spanSz))
 	if retErr != nil {
 		return
@@ -154,10 +151,10 @@ func (c *client) Shutdown(ctx context.Context) error {
 
 func NewDefaultConfig() Config {
 	cfg := Config{
-		SelfMetrics: true,
-		SelfSpans:   true,
+		SelfMetrics:       true,
+		SelfSpans:         true,
 		AdmissionLimitMiB: 64,
-		WaiterLimit: 1000,
+		WaiterLimit:       1000,
 		Batcher: concurrentbatchprocessor.Config{
 			Timeout:            time.Second,
 			SendBatchSize:      1000,

--- a/lightstep/sdk/trace/exporters/otlp/otelcol/client_test.go
+++ b/lightstep/sdk/trace/exporters/otlp/otelcol/client_test.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/otelarrowreceiver"
+	// "github.com/open-telemetry/otel-arrow/collector/admission"
 	"github.com/stretchr/testify/suite"
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/config/confignet"
@@ -44,7 +45,6 @@ import (
 	resourcev1 "go.opentelemetry.io/proto/otlp/resource/v1"
 	tracev1 "go.opentelemetry.io/proto/otlp/trace/v1"
 
-	// "google.golang.org/protobuf/encoding/prototext"
 	"google.golang.org/protobuf/proto"
 )
 
@@ -201,7 +201,7 @@ func (t *clientTestSuite) TestSpan() {
 			{
 				Resource: &resourcev1.Resource{
 					Attributes: []*commonpb.KeyValue{
-						&commonpb.KeyValue{
+						{
 							Key: "property",
 							Value: &commonpb.AnyValue{
 								Value: &commonpb.AnyValue_StringValue{
@@ -209,7 +209,7 @@ func (t *clientTestSuite) TestSpan() {
 								},
 							},
 						},
-						&commonpb.KeyValue{
+						{
 							Key: "service.name",
 							Value: &commonpb.AnyValue{
 								Value: &commonpb.AnyValue_StringValue{
@@ -220,12 +220,12 @@ func (t *clientTestSuite) TestSpan() {
 					},
 				},
 				ScopeSpans: []*tracev1.ScopeSpans{
-					&tracev1.ScopeSpans{
+					{
 						Scope: &commonpb.InstrumentationScope{
 							Name: "test-tracer",
 						},
 						Spans: []*tracev1.Span{
-							&tracev1.Span{
+							{
 								SpanId:  []byte(unqSpanID),
 								TraceId: []byte(unqTraceID),
 								Kind:    tracev1.Span_SPAN_KIND_SERVER,
@@ -235,7 +235,7 @@ func (t *clientTestSuite) TestSpan() {
 									Message: "failed",
 								},
 								Attributes: []*commonpb.KeyValue{
-									&commonpb.KeyValue{
+									{
 										Key: "test-attribute-1",
 										Value: &commonpb.AnyValue{
 											Value: &commonpb.AnyValue_StringValue{
@@ -388,6 +388,9 @@ func (t *clientTestSuite) TestSpanSizeTooLarge() {
 
 	// AdmissionLimitMiB is 0 so we should have no traces arriving.
 	t.Equal(0, len(t.sink.AllTraces()))
-
 	t.assertTimestamps()
+
+	roSpans := []sdktrace.ReadOnlySpan{span.(sdktrace.ReadOnlySpan), child.(sdktrace.ReadOnlySpan)}
+	err = exp.ExportSpans(ctx, roSpans)
+	t.ErrorContains(err, "request size larger than configured limit")
 }

--- a/lightstep/sdk/trace/exporters/otlp/otelcol/size.go
+++ b/lightstep/sdk/trace/exporters/otlp/otelcol/size.go
@@ -1,7 +1,6 @@
 package otelcol
 
 import (
-	"fmt"
 	math_bits "math/bits"
 
 	"go.opentelemetry.io/otel/attribute"
@@ -81,8 +80,6 @@ func sizeOfSpanLinks(links []trace.Link) int {
 			sz += 1 + sovTrace(uint64(link.DroppedAttributeCount))
 		}
 	}
-	fmt.Println("LINK SZ")
-	fmt.Println(sz)
 	return sz
 }
 
@@ -100,7 +97,6 @@ func sizeOfSpanEvents(events []trace.Event) int {
 	}
 	return sz
 }
-
 
 func sizeOfROSpan(span trace.ReadOnlySpan) int {
 	sz := 0

--- a/lightstep/sdk/trace/exporters/otlp/otelcol/size.go
+++ b/lightstep/sdk/trace/exporters/otlp/otelcol/size.go
@@ -1,3 +1,17 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package otelcol
 
 import (

--- a/lightstep/sdk/trace/exporters/otlp/otelcol/size.go
+++ b/lightstep/sdk/trace/exporters/otlp/otelcol/size.go
@@ -1,0 +1,158 @@
+package otelcol
+
+import (
+	"fmt"
+	math_bits "math/bits"
+
+	"go.opentelemetry.io/otel/attribute"
+	otelcodes "go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/sdk/trace"
+	traceapi "go.opentelemetry.io/otel/trace"
+)
+
+func sovTrace(x uint64) (n int) {
+	return (math_bits.Len64(x|1) + 6) / 7
+}
+
+func sizeOfSpanContext(sc traceapi.SpanContext) int {
+	sz := 0
+	spanIDLen := len(sc.SpanID())
+	sz += 1 + spanIDLen + sovTrace(uint64(spanIDLen))
+	// sc.TraceFlags() is a byte
+	sz += 1 + sovTrace(1)
+	tid := len(sc.TraceID())
+	sz += 1 + tid + sovTrace(uint64(tid))
+	ts := sc.TraceState().String()
+	lts := len(ts)
+	sz += 1 + lts + sovTrace(uint64(lts))
+
+	return sz
+}
+
+func sizeOfSpanString(str string) int {
+	length := len(str)
+	return 1 + length + sovTrace(uint64(length))
+}
+
+func sizeOfSpanAttributes(attrs []attribute.KeyValue) int {
+	sz := 0
+
+	for _, attr := range attrs {
+
+		sz += sizeOfSpanString(string(attr.Key))
+
+		switch v := attr.Value.Type(); v {
+		case attribute.BOOL:
+			sz += 1 + sovTrace(1)
+		case attribute.BOOLSLICE:
+			l := len(attr.Value.AsBoolSlice())
+			sz += 1 + l + sovTrace(uint64(l))
+		case attribute.INT64:
+			sz += 1 + sovTrace(8)
+		case attribute.INT64SLICE:
+			l := 8 * len(attr.Value.AsInt64Slice())
+			sz += 1 + l + sovTrace(uint64(l))
+		case attribute.FLOAT64:
+			sz += 1 + sovTrace(8)
+		case attribute.FLOAT64SLICE:
+			l := 8 * len(attr.Value.AsFloat64Slice())
+			sz += 1 + l + sovTrace(uint64(l))
+		case attribute.STRING:
+			l := len(attr.Value.AsString())
+			sz += 1 + l + sovTrace(uint64(l))
+		case attribute.STRINGSLICE:
+			for _, s := range attr.Value.AsStringSlice() {
+				l := len(s)
+				sz += 1 + l + sovTrace(uint64(l))
+			}
+		}
+
+	}
+	return sz
+}
+
+func sizeOfSpanLinks(links []trace.Link) int {
+	sz := 0
+
+	for _, link := range links {
+		sz += sizeOfSpanContext(link.SpanContext)
+		sz += sizeOfSpanAttributes(link.Attributes)
+		if link.DroppedAttributeCount != 0 {
+			sz += 1 + sovTrace(uint64(link.DroppedAttributeCount))
+		}
+	}
+	fmt.Println("LINK SZ")
+	fmt.Println(sz)
+	return sz
+}
+
+func sizeOfSpanEvents(events []trace.Event) int {
+	sz := 0
+
+	for _, event := range events {
+		sz += sizeOfSpanString(event.Name)
+		sz += sizeOfSpanAttributes(event.Attributes)
+		// event.Time is a time.Time
+		sz += 1 + 24 + sovTrace(24)
+		if event.DroppedAttributeCount != 0 {
+			sz += 1 + sovTrace(uint64(event.DroppedAttributeCount))
+		}
+	}
+	return sz
+}
+
+
+func sizeOfROSpan(span trace.ReadOnlySpan) int {
+	sz := 0
+	sz += sizeOfSpanString(span.Name())
+
+	sz += sizeOfSpanContext(span.SpanContext())
+
+	sz += sizeOfSpanContext(span.Parent())
+
+	sz += sizeOfSpanString(span.SpanKind().String())
+
+	// span.StartTime() and span.EndTime() is a time.Time that consists of a two int64
+	// and an optional pointer for location. To be conservative count 24 bytes.
+	sz += 1 + 24 + sovTrace(uint64(24))
+	sz += 1 + 24 + sovTrace(uint64(24))
+
+	sz += sizeOfSpanAttributes(span.Attributes())
+
+	sz += sizeOfSpanLinks(span.Links())
+
+	sz += sizeOfSpanEvents(span.Events())
+
+	if span.Status().Code != otelcodes.Unset {
+		sz += 1 + sovTrace(uint64(span.Status().Code))
+	}
+	sz += sizeOfSpanString(span.Status().Description)
+
+	sz += sizeOfSpanString(span.InstrumentationScope().Name)
+	sz += sizeOfSpanString(span.InstrumentationScope().Version)
+	sz += sizeOfSpanString(span.InstrumentationScope().SchemaURL)
+
+	sz += sizeOfSpanString(span.InstrumentationLibrary().Name)
+	sz += sizeOfSpanString(span.InstrumentationLibrary().Version)
+	sz += sizeOfSpanString(span.InstrumentationLibrary().SchemaURL)
+
+	sz += sizeOfSpanString(span.Resource().SchemaURL())
+	sz += sizeOfSpanAttributes(span.Resource().Attributes())
+
+	if span.DroppedAttributes() != 0 {
+		sz += 1 + sovTrace(uint64(span.DroppedAttributes()))
+	}
+
+	if span.DroppedLinks() != 0 {
+		sz += 1 + sovTrace(uint64(span.DroppedLinks()))
+	}
+
+	if span.DroppedEvents() != 0 {
+		sz += 1 + sovTrace(uint64(span.DroppedEvents()))
+	}
+	if span.ChildSpanCount() != 0 {
+		sz += 1 + sovTrace(uint64(span.ChildSpanCount()))
+	}
+
+	return sz
+}

--- a/lightstep/sdk/trace/exporters/otlp/otelcol/size_test.go
+++ b/lightstep/sdk/trace/exporters/otlp/otelcol/size_test.go
@@ -1,3 +1,17 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package otelcol
 
 import (

--- a/lightstep/sdk/trace/exporters/otlp/otelcol/size_test.go
+++ b/lightstep/sdk/trace/exporters/otlp/otelcol/size_test.go
@@ -1,0 +1,99 @@
+package otelcol
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.opentelemetry.io/collector/pdata/ptrace/ptraceotlp"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/trace"
+	"go.opentelemetry.io/otel/sdk/resource"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+)
+
+func TestSizeOfSimpleROSpan(t *testing.T) {
+
+	tests := []struct {
+		name          string
+		numSpanAttrs  int
+		numSpanEvents int
+		numSpanLinks  int
+	}{
+		{
+			name:              "simple",
+			numSpanAttrs: 10,
+		},
+		{
+			name:              "many_attributes",
+			numSpanAttrs: 100000,
+		},
+		{
+			name:              "with_events",
+			numSpanAttrs: 100000,
+			numSpanEvents: 10000,
+		},
+		{
+			name:              "with_links",
+			numSpanAttrs: 100000,
+			numSpanEvents: 10000,
+			numSpanLinks: 1000,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			tprovider := sdktrace.NewTracerProvider(
+				sdktrace.WithResource(
+					resource.NewSchemaless(testResourceAttrs...),
+				),
+			)
+			tracer := tprovider.Tracer("test-tracer")
+			_, span := tracer.Start(ctx, "ExecuteRequest", trace.WithSpanKind(trace.SpanKindServer))
+
+			for i := 0; i < tt.numSpanAttrs; i++ {
+				key := fmt.Sprintf("test-attribute-%d", i)
+				val := fmt.Sprintf("test-value-%d", i)
+				span.SetAttributes(attribute.String(key, val))
+			}
+
+			for i := 0; i < tt.numSpanEvents; i++ {
+				key := fmt.Sprintf("test-event-attribute-%d", i)
+				val := fmt.Sprintf("test-event-value-%d", i)
+				span.AddEvent("test event", trace.WithAttributes(attribute.String(key, val)))
+			}
+
+			for i := 0; i < tt.numSpanLinks; i++ {
+				key := fmt.Sprintf("test-link-attribute-%d", i)
+				val := fmt.Sprintf("test-link-value-%d", i)
+				linkCtx, _ := tracer.Start(context.Background(), "LinkedRequest", trace.WithSpanKind(trace.SpanKindServer))
+
+				link := trace.LinkFromContext(linkCtx, attribute.String(key, val))
+
+				span.AddLink(link)
+			}
+
+			span.SetStatus(codes.Error, "failed")
+			span.End()
+
+			roSpan := span.(sdktrace.ReadOnlySpan)
+
+			c := &client{}
+			traces := ptraceotlp.NewExportRequestFromTraces(c.d2pd([]sdktrace.ReadOnlySpan{roSpan}))
+			data, err := traces.MarshalProto()
+			require.NoError(t, err)
+
+			protobufSz := float64(len(data))
+			ROSpanSz := float64(sizeOfROSpan(roSpan))
+			percentDiff := math.Abs((ROSpanSz - protobufSz)/protobufSz)
+
+			assert.LessOrEqual(t, percentDiff, 0.1)
+			fmt.Println(percentDiff)
+		})
+	}
+}

--- a/lightstep/sdk/trace/exporters/otlp/otelcol/size_test.go
+++ b/lightstep/sdk/trace/exporters/otlp/otelcol/size_test.go
@@ -12,9 +12,9 @@ import (
 	"go.opentelemetry.io/collector/pdata/ptrace/ptraceotlp"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
-	"go.opentelemetry.io/otel/trace"
 	"go.opentelemetry.io/otel/sdk/resource"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/trace"
 )
 
 func TestSizeOfSimpleROSpan(t *testing.T) {
@@ -26,23 +26,23 @@ func TestSizeOfSimpleROSpan(t *testing.T) {
 		numSpanLinks  int
 	}{
 		{
-			name:              "simple",
+			name:         "simple",
 			numSpanAttrs: 10,
 		},
 		{
-			name:              "many_attributes",
+			name:         "many_attributes",
 			numSpanAttrs: 100000,
 		},
 		{
-			name:              "with_events",
-			numSpanAttrs: 100000,
+			name:          "with_events",
+			numSpanAttrs:  100000,
 			numSpanEvents: 10000,
 		},
 		{
-			name:              "with_links",
-			numSpanAttrs: 100000,
+			name:          "with_links",
+			numSpanAttrs:  100000,
 			numSpanEvents: 10000,
-			numSpanLinks: 1000,
+			numSpanLinks:  1000,
 		},
 	}
 	for _, tt := range tests {
@@ -90,10 +90,9 @@ func TestSizeOfSimpleROSpan(t *testing.T) {
 
 			protobufSz := float64(len(data))
 			ROSpanSz := float64(sizeOfROSpan(roSpan))
-			percentDiff := math.Abs((ROSpanSz - protobufSz)/protobufSz)
+			percentDiff := math.Abs((ROSpanSz - protobufSz) / protobufSz)
 
 			assert.LessOrEqual(t, percentDiff, 0.1)
-			fmt.Println(percentDiff)
 		})
 	}
 }

--- a/lightstep/sdk/trace/go.mod
+++ b/lightstep/sdk/trace/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/lightstep/otel-launcher-go/lightstep/sdk/internal v1.30.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/otelarrowexporter v0.105.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/otelarrowreceiver v0.105.0
+	github.com/open-telemetry/otel-arrow/collector v0.24.0
 	github.com/open-telemetry/otel-arrow/collector/processor/concurrentbatchprocessor v0.25.0
 	github.com/stretchr/testify v1.9.0
 	go.opentelemetry.io/collector/component v0.105.0
@@ -71,7 +72,6 @@ require (
 	github.com/mostynb/go-grpc-compression v1.2.3 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/open-telemetry/otel-arrow v0.24.0 // indirect
-	github.com/open-telemetry/otel-arrow/collector v0.24.0 // indirect
 	github.com/pierrec/lz4/v4 v4.1.21 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/prometheus/client_golang v1.19.1 // indirect

--- a/pipelines/go.mod
+++ b/pipelines/go.mod
@@ -107,9 +107,13 @@ require (
 
 require (
 	github.com/apache/arrow/go/v16 v16.1.0 // indirect
+	github.com/bahlo/generic-list-go v0.2.0 // indirect
+	github.com/buger/jsonparser v1.1.1 // indirect
 	github.com/go-viper/mapstructure/v2 v2.0.0-alpha.1 // indirect
 	github.com/google/uuid v1.6.0 // indirect
+	github.com/mailru/easyjson v0.7.7 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/otelarrowexporter v0.105.0 // indirect
+	github.com/wk8/go-ordered-map/v2 v2.1.8 // indirect
 	go.opentelemetry.io/collector/config/configretry v1.12.0 // indirect
 	go.opentelemetry.io/collector/internal/globalgates v0.105.0 // indirect
 	golang.org/x/exp v0.0.0-20240506185415-9bf2ced13842 // indirect

--- a/pipelines/go.sum
+++ b/pipelines/go.sum
@@ -65,6 +65,7 @@ github.com/grpc-ecosystem/grpc-gateway/v2 v2.20.0 h1:bkypFPDjIYGfCYD5mRBvpqxfYX1
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.20.0/go.mod h1:P+Lt/0by1T8bfcF3z737NnSbmxQAppXMRziHUxPOC8k=
 github.com/hashicorp/go-version v1.7.0 h1:5tqGy27NaOTB8yJKUZELlFAS/LTKJkrmONwQKeRZfjY=
 github.com/hashicorp/go-version v1.7.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
+github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
 github.com/jung-kurt/gofpdf v1.0.3-0.20190309125859-24315acbbda5/go.mod h1:7Id9E/uU8ce6rXgefFLlgrJj/GYY22cpxn+r32jIOes=


### PR DESCRIPTION
**Description:**

This PR adds in admission control for the traces sdk pipeline. This is to address high memory usage for some services using our traces SDK.  This PR avoids unnecessary allocations by rejecting requests before they are converted to pdata if the approximated request size is larger than the configured limit. 

The traces sdk has a concurrentbatchprocessor in its collector pipeline which might be ineffective at dropping requests in the case that requests are batched quicker than the requests themselves are entering the sdk. The concurrentbatchprocessor also does not have a waiter limit.
