### PR TITLE
Wrap the SDK-internal MeterProvider with a shim to replace otelcol_ with otelsdk_

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## Unreleased
 
+- Metrics/Traces exporter [#760](https://github.com/lightstep/otel-launcher-go/pull/760)
+- Traces exporter: allow custom meter/trace providers [#739](https://github.com/lightstep/otel-launcher-go/pull/739)
 - Use correct default retry settings. [#741](https://github.com/lightstep/otel-launcher-go/pull/741)
 
 ## [1.30.0](https://github.com/lightstep/otel-launcher-go/releases/tag/v1.30.0) - 2024-07-17

--- a/lightstep/sdk/internal/common.go
+++ b/lightstep/sdk/internal/common.go
@@ -15,10 +15,13 @@
 package internal
 
 import (
+	"strings"
 	"sync"
 
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+	"go.opentelemetry.io/otel/metric/embedded"
 	"go.opentelemetry.io/otel/sdk/resource"
 )
 
@@ -100,4 +103,91 @@ func CopyAttributes(dest pcommon.Map, src attribute.Set) {
 			panic("unhandled case")
 		}
 	}
+}
+
+type notelMeterProvider struct {
+	embedded.MeterProvider
+	meterProvider metric.MeterProvider
+}
+
+type notelMeter struct {
+	embedded.Meter
+	meter metric.Meter
+}
+
+func (no notelMeterProvider) Meter(name string, opts ...metric.MeterOption) metric.Meter {
+	return notelMeter{
+		meter: no.meterProvider.Meter(name, opts...),
+	}
+}
+
+func fixName(name string) string {
+	if strings.HasPrefix(name, "otelcol_") {
+		return "otelsdk_" + name[8:]
+	}
+	return name
+}
+
+func (no notelMeter) Int64Counter(name string, options ...metric.Int64CounterOption) (metric.Int64Counter, error) {
+	return no.meter.Int64Counter(fixName(name), options...)
+}
+
+func (no notelMeter) Int64UpDownCounter(name string, options ...metric.Int64UpDownCounterOption) (metric.Int64UpDownCounter, error) {
+	return no.meter.Int64UpDownCounter(fixName(name), options...)
+}
+
+func (no notelMeter) Int64Histogram(name string, options ...metric.Int64HistogramOption) (metric.Int64Histogram, error) {
+	return no.meter.Int64Histogram(fixName(name), options...)
+}
+
+func (no notelMeter) Int64Gauge(name string, options ...metric.Int64GaugeOption) (metric.Int64Gauge, error) {
+	return no.meter.Int64Gauge(fixName(name), options...)
+}
+
+func (no notelMeter) Int64ObservableCounter(name string, options ...metric.Int64ObservableCounterOption) (metric.Int64ObservableCounter, error) {
+	return no.meter.Int64ObservableCounter(fixName(name), options...)
+}
+
+func (no notelMeter) Int64ObservableUpDownCounter(name string, options ...metric.Int64ObservableUpDownCounterOption) (metric.Int64ObservableUpDownCounter, error) {
+	return no.meter.Int64ObservableUpDownCounter(fixName(name), options...)
+}
+
+func (no notelMeter) Int64ObservableGauge(name string, options ...metric.Int64ObservableGaugeOption) (metric.Int64ObservableGauge, error) {
+	return no.meter.Int64ObservableGauge(fixName(name), options...)
+}
+
+func (no notelMeter) Float64Counter(name string, options ...metric.Float64CounterOption) (metric.Float64Counter, error) {
+	return no.meter.Float64Counter(fixName(name), options...)
+}
+
+func (no notelMeter) Float64UpDownCounter(name string, options ...metric.Float64UpDownCounterOption) (metric.Float64UpDownCounter, error) {
+	return no.meter.Float64UpDownCounter(fixName(name), options...)
+}
+
+func (no notelMeter) Float64Histogram(name string, options ...metric.Float64HistogramOption) (metric.Float64Histogram, error) {
+	return no.meter.Float64Histogram(fixName(name), options...)
+}
+
+func (no notelMeter) Float64Gauge(name string, options ...metric.Float64GaugeOption) (metric.Float64Gauge, error) {
+	return no.meter.Float64Gauge(fixName(name), options...)
+}
+
+func (no notelMeter) Float64ObservableCounter(name string, options ...metric.Float64ObservableCounterOption) (metric.Float64ObservableCounter, error) {
+	return no.meter.Float64ObservableCounter(fixName(name), options...)
+}
+
+func (no notelMeter) Float64ObservableUpDownCounter(name string, options ...metric.Float64ObservableUpDownCounterOption) (metric.Float64ObservableUpDownCounter, error) {
+	return no.meter.Float64ObservableUpDownCounter(fixName(name), options...)
+}
+
+func (no notelMeter) Float64ObservableGauge(name string, options ...metric.Float64ObservableGaugeOption) (metric.Float64ObservableGauge, error) {
+	return no.meter.Float64ObservableGauge(fixName(name), options...)
+}
+
+func (no notelMeter) RegisterCallback(f metric.Callback, instruments ...metric.Observable) (metric.Registration, error) {
+	return no.meter.RegisterCallback(f, instruments...)
+}
+
+func NOTelColMeterProvider(m metric.MeterProvider) metric.MeterProvider {
+	return &notelMeterProvider{meterProvider: m}
 }

--- a/lightstep/sdk/internal/go.mod
+++ b/lightstep/sdk/internal/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/stretchr/testify v1.9.0
 	go.opentelemetry.io/collector/pdata v1.12.0
 	go.opentelemetry.io/otel v1.28.0
+	go.opentelemetry.io/otel/metric v1.28.0
 	go.opentelemetry.io/otel/sdk v1.28.0
 )
 
@@ -20,7 +21,6 @@ require (
 	github.com/kr/text v0.2.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/rogpeppe/go-internal v1.11.0 // indirect
-	go.opentelemetry.io/otel/metric v1.28.0 // indirect
 	go.opentelemetry.io/otel/trace v1.28.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	golang.org/x/net v0.25.0 // indirect

--- a/lightstep/sdk/metric/exporters/otlp/otelcol/client.go
+++ b/lightstep/sdk/metric/exporters/otlp/otelcol/client.go
@@ -167,7 +167,7 @@ func NewExporter(ctx context.Context, cfg Config) (metric.PushExporter, error) {
 	}
 
 	if cfg.SelfMetrics {
-		c.settings.TelemetrySettings.MeterProvider = otel.GetMeterProvider()
+		c.settings.TelemetrySettings.MeterProvider = internal.NOTelColMeterProvider(otel.GetMeterProvider())
 		c.settings.TelemetrySettings.MetricsLevel = configtelemetry.LevelNormal
 		c.counter, _ = c.settings.TelemetrySettings.MeterProvider.Meter("lightstep/sdk/metric").Int64Counter("otelsdk.telemetry.items")
 	} else {

--- a/lightstep/sdk/trace/exporters/otlp/otelcol/client.go
+++ b/lightstep/sdk/trace/exporters/otlp/otelcol/client.go
@@ -241,6 +241,7 @@ func NewExporter(ctx context.Context, cfg Config, opts ...func(options *Exporter
 		} else {
 			c.settings.TelemetrySettings.MeterProvider = options.MeterProvider
 		}
+		c.settings.TelemetrySettings.MeterProvider = internal.NOTelColMeterProvider(c.settings.TelemetrySettings.MeterProvider)
 		c.settings.TelemetrySettings.MetricsLevel = configtelemetry.LevelNormal
 		// Note: the metrics SDK creates a counter at this
 		// point and counts points.  The same is not done here


### PR DESCRIPTION
**Description:** This will alleviate heavy confusion resulting from all internal Go trace/metrics SDKs reporting collector metrics that we use to monitor internal collectors.
