### PR TITLE
Use the metrics batcher (accident)

### DIFF
--- a/lightstep/sdk/metric/exporters/otlp/otelcol/client.go
+++ b/lightstep/sdk/metric/exporters/otlp/otelcol/client.go
@@ -213,7 +213,7 @@ func (c *client) ExportMetrics(ctx context.Context, data data.Metrics) error {
 		c.tracer,
 		c.counter,
 		&c.ResourceMap,
-		c.exporter,
+		c.batcher,
 		true, // use exponential histograms
 	)
 }


### PR DESCRIPTION
**Description:** The OTLP exporter is bypassing its own batcher, responsible for excessively large metrics SDK exports in certain Lightstep binaries.

Originates in https://github.com/lightstep/otel-launcher-go/pull/775, afaict.