### PR TITLE
Use metrics batcher

### DIFF
--- a/lightstep/sdk/metric/exporters/otlp/otelcol/client.go
+++ b/lightstep/sdk/metric/exporters/otlp/otelcol/client.go
@@ -213,7 +213,7 @@ func (c *client) ExportMetrics(ctx context.Context, data data.Metrics) error {
 		c.tracer,
 		c.counter,
 		&c.ResourceMap,
-		c.exporter,
+		c.batcher,
 		true, // use exponential histograms
 	)
 }


### PR DESCRIPTION
This applies the same fix from #817 to v1.33.0, which we will release as v1.33.1 to fix an issue with large metrics exports.